### PR TITLE
Quake type and methods

### DIFF
--- a/sc3ml/idempotent.go
+++ b/sc3ml/idempotent.go
@@ -1,0 +1,45 @@
+package sc3ml
+
+import (
+	"sync"
+	"time"
+)
+
+// IdpQuake can be used to implement an idempotent receiver for Quakes.
+// Thread safe.
+type IdpQuake struct {
+	idp map[string]Quake
+	mu  sync.RWMutex
+}
+
+// Seen returns true if the Quake q has been previously
+// seen via Add().  False otherwise.
+// Quakes older than 60 minutes are evicted from i before checking for q.
+func (i *IdpQuake) Seen(q Quake) bool {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	if i.idp == nil {
+		i.idp = make(map[string]Quake)
+	}
+
+	c := time.Now().UTC().Add(time.Duration(-60 * time.Minute))
+
+	for _, e := range i.idp {
+		if e.Time.Before(c) {
+			delete(i.idp, e.PublicID)
+		}
+	}
+
+	_, b := i.idp[q.PublicID]
+
+	return b
+}
+
+// Add adds Quake.
+func (i *IdpQuake) Add(q Quake) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	i.idp[q.PublicID] = q
+}

--- a/sc3ml/idempotent_test.go
+++ b/sc3ml/idempotent_test.go
@@ -1,0 +1,42 @@
+package sc3ml
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIdpQuake(t *testing.T) {
+	idpq := IdpQuake{}
+
+	q := Quake{
+		Time:     time.Now().UTC().Add(time.Duration(-15 * time.Minute)),
+		PublicID: "1234",
+	}
+
+	if idpq.Seen(q) != false {
+		t.Error("should not have seen quake 1234")
+	}
+
+	idpq.Add(q)
+
+	if idpq.Seen(q) != true {
+		t.Error("should have seen quake 1234")
+	}
+
+	// an old quake
+	o := Quake{
+		Time:     time.Now().UTC().Add(time.Duration(-100 * time.Minute)),
+		PublicID: "1234567",
+	}
+
+	idpq.Add(o)
+
+	if idpq.Seen(o) != false {
+		t.Error("should not have seen quake 1234567 - it's old and should have been removed.")
+	}
+
+	if idpq.Seen(q) != true {
+		t.Error("should have seen quake 1234")
+	}
+
+}

--- a/sc3ml/quake.go
+++ b/sc3ml/quake.go
@@ -1,0 +1,155 @@
+package sc3ml
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"time"
+)
+
+var alertAge = time.Duration(-60) * time.Minute
+
+// Quake for earthquakes.
+type Quake struct {
+	PublicID              string
+	Type                  string
+	AgencyID              string
+	ModificationTime      time.Time
+	Time                  time.Time
+	Latitude              float64
+	Longitude             float64
+	Depth                 float64
+	DepthType             string
+	MethodID              string
+	EarthModelID          string
+	EvaluationMode        string
+	EvaluationStatus      string
+	UsedPhaseCount        int
+	UsedStationCount      int
+	StandardError         float64
+	AzimuthalGap          float64
+	MinimumDistance       float64
+	Magnitude             float64
+	MagnitudeUncertainty  float64
+	MagnitudeType         string
+	MagnitudeStationCount int
+	Site                  string
+}
+
+// Status returns a simplified status.
+func (q *Quake) Status() string {
+	switch {
+	case q.Type == "not existing":
+		return "deleted"
+	case q.Type == "duplicate":
+		return "duplicate"
+	case q.EvaluationMode == "manual":
+		return "reviewed"
+	case q.EvaluationStatus == "confirmed":
+		return "reviewed"
+	default:
+		return "automatic"
+	}
+}
+
+// Quality returns a simplified quality.
+func (q *Quake) Quality() string {
+	status := q.Status()
+
+	switch {
+	case status == "reviewed":
+		return "best"
+	case status == "deleted":
+		return "deleted"
+	case q.UsedPhaseCount >= 20 && q.MagnitudeStationCount >= 10:
+		return "good"
+	default:
+		return "caution"
+	}
+}
+
+// Alert returns true if the quake should be considered for alerting, false
+// with a reason if not.
+func (q *Quake) Alert() (bool, string) {
+	switch {
+	case q.Status() == "deleted":
+		return false, fmt.Sprintf("%s status deleted not suitable for alerting.", q.PublicID)
+	case q.Status() == "duplicate":
+		return false, fmt.Sprintf("%s status duplicate not suitable for alerting.", q.PublicID)
+	case q.Status() == "automatic" && (q.UsedPhaseCount < 20 || q.MagnitudeStationCount < 10):
+		return false, fmt.Sprintf("%s unreviewed with %d phases and %d magnitudes not suitable for alerting.", q.PublicID, q.UsedPhaseCount, q.MagnitudeStationCount)
+	case q.Status() == "automatic" && !(q.Depth >= 0.1 && q.AzimuthalGap <= 320.0 && q.MinimumDistance <= 2.5):
+		return false, fmt.Sprintf("%s automatic with poor location criteria", q.PublicID)
+	case q.Time.Before(time.Now().UTC().Add(alertAge)):
+		return false, fmt.Sprintf("%s to old for alerting", q.PublicID)
+	default:
+		return true, ""
+	}
+}
+
+// manual returns true if the quake has been manually reviewed in some way.
+func (q *Quake) Manual() bool {
+	switch {
+	case q.Type == "not existing":
+		return true
+	case q.Type == "duplicate":
+		return true
+	case q.EvaluationMode == "manual":
+		return true
+	case q.EvaluationStatus == "confirmed":
+		return true
+	default:
+		return false
+	}
+}
+
+func FromSC3ML(r io.Reader) (Quake, error) {
+	var s Seiscomp
+
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return Quake{}, err
+	}
+
+	err = Unmarshal(b, &s)
+	if err != nil {
+		return Quake{}, err
+	}
+
+	return Quake{
+		PublicID:              s.EventParameters.Events[0].PublicID,
+		Type:                  s.EventParameters.Events[0].Type,
+		AgencyID:              s.EventParameters.Events[0].CreationInfo.AgencyID,
+		MethodID:              s.EventParameters.Events[0].PreferredOrigin.MethodID,
+		EarthModelID:          s.EventParameters.Events[0].PreferredOrigin.EarthModelID,
+		EvaluationMode:        s.EventParameters.Events[0].PreferredOrigin.EvaluationMode,
+		EvaluationStatus:      s.EventParameters.Events[0].PreferredOrigin.EvaluationStatus,
+		DepthType:             s.EventParameters.Events[0].PreferredOrigin.DepthType,
+		MagnitudeType:         s.EventParameters.Events[0].PreferredMagnitude.Type,
+		Time:                  s.EventParameters.Events[0].PreferredOrigin.Time.Value,
+		Latitude:              s.EventParameters.Events[0].PreferredOrigin.Latitude.Value,
+		Longitude:             s.EventParameters.Events[0].PreferredOrigin.Longitude.Value,
+		Depth:                 s.EventParameters.Events[0].PreferredOrigin.Depth.Value,
+		StandardError:         s.EventParameters.Events[0].PreferredOrigin.Quality.StandardError,
+		AzimuthalGap:          s.EventParameters.Events[0].PreferredOrigin.Quality.AzimuthalGap,
+		MinimumDistance:       s.EventParameters.Events[0].PreferredOrigin.Quality.MinimumDistance,
+		UsedPhaseCount:        int(s.EventParameters.Events[0].PreferredOrigin.Quality.UsedPhaseCount),
+		UsedStationCount:      int(s.EventParameters.Events[0].PreferredOrigin.Quality.UsedStationCount),
+		MagnitudeStationCount: int(s.EventParameters.Events[0].PreferredMagnitude.StationCount),
+		Magnitude:             s.EventParameters.Events[0].PreferredMagnitude.Magnitude.Value,
+		MagnitudeUncertainty:  s.EventParameters.Events[0].PreferredMagnitude.Magnitude.Uncertainty,
+		ModificationTime:      s.EventParameters.Events[0].ModificationTime,
+	}, nil
+}
+
+// Publish returns true if the quake should be considered for publishing.
+func (q *Quake) Publish() bool {
+	switch q.Site {
+	case "primary":
+		return true
+	case "backup":
+		return q.Manual()
+	default:
+		return false
+	}
+}

--- a/sc3ml/quake_test.go
+++ b/sc3ml/quake_test.go
@@ -1,0 +1,268 @@
+package sc3ml
+
+import (
+	"os"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestFromSC3ML(t *testing.T) {
+	for _, input := range []string{"2015p768477_0.7.xml", "2015p768477_0.8.xml", "2015p768477_0.9.xml"} {
+		r, err := os.Open("testdata/" + input)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		e, err := FromSC3ML(r)
+		if err != nil {
+			t.Errorf("%s: %s", input, err.Error())
+		}
+		r.Close()
+
+		if e.PublicID != "2015p768477" {
+			t.Errorf("%s: expected publicID 2015p768477 got %s", input, e.PublicID)
+		}
+
+		if e.Type != "earthquake" {
+			t.Errorf("%s: expected type earthquake got %s", input, e.Type)
+		}
+
+		if e.Time.Format(time.RFC3339Nano) != "2015-10-12T08:05:01.717692Z" {
+			t.Errorf("%s: expected 2015-10-12T08:05:01.717692Z, got %s", input, e.Time.Format(time.RFC3339Nano))
+		}
+
+		if e.Latitude != -40.57806609 {
+			t.Errorf("%s: Latitude expected -40.57806609 got %f", input, e.Latitude)
+		}
+
+		if e.Longitude != 176.3257242 {
+			t.Errorf("%s: Longitude expected 176.3257242 got %f", input, e.Longitude)
+		}
+
+		if e.Depth != 23.28125 {
+			t.Errorf("%s: Depth expected 23.28125 got %f", input, e.Depth)
+		}
+
+		if e.MethodID != "NonLinLoc" {
+			t.Errorf("%s: MethodID expected NonLinLoc got %s", input, e.MethodID)
+		}
+
+		if e.EarthModelID != "nz3drx" {
+			t.Errorf("%s: EarthModelID expected NonLinLoc got %s", input, e.EarthModelID)
+		}
+
+		if e.StandardError != 0.5592857863 {
+			t.Errorf("%s: StandardError expected 0.5592857863 got %f", input, e.StandardError)
+		}
+
+		if e.AzimuthalGap != 166.4674465 {
+			t.Errorf("%s: AzimuthalGap expected 166.4674465 got %f", input, e.AzimuthalGap)
+		}
+
+		if e.MinimumDistance != 0.1217162272 {
+			t.Errorf("%s: MinimumDistance expected 0.1217162272 got %f", input, e.MinimumDistance)
+		}
+
+		if e.UsedPhaseCount != 44 {
+			t.Errorf("%s: UsedPhaseCount expected 44 got %d", input, e.UsedPhaseCount)
+		}
+
+		if e.UsedStationCount != 32 {
+			t.Errorf("%s: UsedStationCount expected 32 got %d", input, e.UsedStationCount)
+		}
+
+		if e.Magnitude != 5.691131913 {
+			t.Errorf("%s: Magnitude expected M got %s", input, e.Magnitude)
+		}
+
+		if e.MagnitudeUncertainty != 0 {
+			t.Errorf("%s: uncertainty expected 0 got %f", input, e.MagnitudeUncertainty)
+		}
+
+		if e.MagnitudeStationCount != 171 {
+			t.Errorf("%s: e.MagnitudeStationCount expected 171 got %d", input, e.MagnitudeStationCount)
+		}
+
+		if e.ModificationTime.Format(time.RFC3339Nano) != "2015-10-12T22:46:41.228824Z" {
+			t.Errorf("%s: Modification time expected 2015-10-12T22:46:41.228824Z got %s", input, e.ModificationTime.Format(time.RFC3339Nano))
+		}
+	}
+}
+
+func TestManual(t *testing.T) {
+	in := []struct {
+		id     string
+		q      Quake
+		manual bool
+	}{
+		{id: loc(), q: Quake{}, manual: false},
+		{id: loc(), q: Quake{Type: "not existing"}, manual: true},
+		{id: loc(), q: Quake{Type: "duplicate"}, manual: true},
+		{id: loc(), q: Quake{EvaluationMode: "manual"}, manual: true},
+		{id: loc(), q: Quake{EvaluationStatus: "confirmed"}, manual: true},
+	}
+
+	for _, v := range in {
+		if v.q.Manual() != v.manual {
+			t.Errorf("%s expected manual %t got %t", v.id, v.manual, v.q.Manual())
+		}
+	}
+}
+
+func TestPublish(t *testing.T) {
+	in := []struct {
+		id      string
+		q       Quake
+		publish bool
+	}{
+		{id: loc(), q: Quake{Site: "backup"}, publish: false},
+		{id: loc(), q: Quake{Type: "not existing", Site: "backup"}, publish: true},
+		{id: loc(), q: Quake{Type: "duplicate", Site: "backup"}, publish: true},
+		{id: loc(), q: Quake{EvaluationMode: "manual", Site: "backup"}, publish: true},
+		{id: loc(), q: Quake{EvaluationStatus: "confirmed", Site: "backup"}, publish: true},
+		{id: loc(), q: Quake{Site: "primary"}, publish: true},
+		{id: loc(), q: Quake{Type: "not existing", Site: "primary"}, publish: true},
+		{id: loc(), q: Quake{Type: "duplicate", Site: "primary"}, publish: true},
+		{id: loc(), q: Quake{EvaluationMode: "manual", Site: "primary"}, publish: true},
+		{id: loc(), q: Quake{EvaluationStatus: "confirmed", Site: "primary"}, publish: true},
+	}
+
+	for _, v := range in {
+		if v.q.Publish() != v.publish {
+			t.Errorf("%s expected publish %t got %t", v.id, v.publish, v.q.Publish())
+		}
+	}
+}
+
+func TestStatus(t *testing.T) {
+	in := []struct {
+		id     string
+		q      Quake
+		status string
+	}{
+		{id: loc(), q: Quake{}, status: "automatic"},
+		{id: loc(), q: Quake{Type: "not existing"}, status: "deleted"},
+		{id: loc(), q: Quake{Type: "not existing", EvaluationMode: "manual"}, status: "deleted"},
+		{id: loc(), q: Quake{Type: "not existing", EvaluationStatus: "confirmed"}, status: "deleted"},
+		{id: loc(), q: Quake{Type: "not existing", EvaluationMode: "manual", EvaluationStatus: "confirmed"}, status: "deleted"},
+		{id: loc(), q: Quake{Type: "duplicate"}, status: "duplicate"},
+		{id: loc(), q: Quake{Type: "duplicate", EvaluationMode: "manual"}, status: "duplicate"},
+		{id: loc(), q: Quake{Type: "duplicate", EvaluationStatus: "confirmed"}, status: "duplicate"},
+		{id: loc(), q: Quake{Type: "duplicate", EvaluationMode: "manual", EvaluationStatus: "confirmed"}, status: "duplicate"},
+		{id: loc(), q: Quake{EvaluationMode: "manual"}, status: "reviewed"},
+		{id: loc(), q: Quake{EvaluationStatus: "confirmed"}, status: "reviewed"},
+	}
+
+	for _, v := range in {
+		if v.q.Status() != v.status {
+			t.Errorf("%s expected status %s got %s", v.id, v.status, v.q.Status())
+		}
+	}
+}
+
+func TestQuality(t *testing.T) {
+	in := []struct {
+		id      string
+		q       Quake
+		quality string
+	}{
+		{id: loc(), q: Quake{}, quality: "caution"},
+		{id: loc(), q: Quake{EvaluationMode: "manual"}, quality: "best"},
+		{id: loc(), q: Quake{Type: "not existing", EvaluationMode: "manual"}, quality: "deleted"},
+		{id: loc(), q: Quake{Type: "not existing", EvaluationStatus: "confirmed"}, quality: "deleted"},
+		{id: loc(), q: Quake{Type: "not existing", EvaluationMode: "manual", EvaluationStatus: "confirmed"}, quality: "deleted"},
+		{id: loc(), q: Quake{UsedPhaseCount: 10, MagnitudeStationCount: 4}, quality: "caution"},
+		{id: loc(), q: Quake{UsedPhaseCount: 19, MagnitudeStationCount: 10}, quality: "caution"},
+		{id: loc(), q: Quake{UsedPhaseCount: 20, MagnitudeStationCount: 9}, quality: "caution"},
+		{id: loc(), q: Quake{UsedPhaseCount: 20, MagnitudeStationCount: 10}, quality: "good"},
+	}
+
+	for _, v := range in {
+		if v.q.Quality() != v.quality {
+			t.Errorf("%s expected quality %s got %s", v.id, v.quality, v.q.Quality())
+		}
+	}
+}
+
+func TestAlert(t *testing.T) {
+	in := []struct {
+		id    string
+		q     Quake
+		alert bool
+	}{
+		{id: loc(), alert: false,
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "automatic", UsedPhaseCount: 8, MagnitudeStationCount: 8, Depth: 10.0, AzimuthalGap: 200, MinimumDistance: 1.0}},
+		{id: loc(), alert: true,
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "manual", UsedPhaseCount: 8, MagnitudeStationCount: 8, Depth: 10.0, AzimuthalGap: 200, MinimumDistance: 1.0}},
+		{id: loc(), alert: true,
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "", EvaluationStatus: "confirmed", UsedPhaseCount: 28, MagnitudeStationCount: 28, Depth: 10.0, AzimuthalGap: 200, MinimumDistance: 1.0}},
+		{id: loc(), alert: true,
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "", EvaluationStatus: "confirmed", UsedPhaseCount: 8, MagnitudeStationCount: 8, Depth: 10.0, AzimuthalGap: 200, MinimumDistance: 1.0}},
+		{id: loc(), alert: false,
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "automatic", UsedPhaseCount: 22, MagnitudeStationCount: 8, Depth: 10.0, AzimuthalGap: 200, MinimumDistance: 1.0}},
+		{id: loc(), alert: true,
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "automatic", UsedPhaseCount: 22, MagnitudeStationCount: 12, Depth: 10.0, AzimuthalGap: 200, MinimumDistance: 1.0}},
+		{id: loc(), alert: false,
+			q: Quake{Time: time.Now().UTC(), Type: "not existing", EvaluationMode: "automatic", UsedPhaseCount: 22, MagnitudeStationCount: 12, Depth: 10.0, AzimuthalGap: 200, MinimumDistance: 1.0}},
+		{id: loc(), alert: false,
+			q: Quake{Time: time.Now().UTC(), Type: "duplicate", EvaluationMode: "automatic", UsedPhaseCount: 22, MagnitudeStationCount: 12, Depth: 10.0, AzimuthalGap: 200, MinimumDistance: 1.0}},
+		{id: loc(), alert: false, // shallow automatic shouldn't alert
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "automatic", UsedPhaseCount: 22, MagnitudeStationCount: 12, Depth: 0.01, AzimuthalGap: 200, MinimumDistance: 1.0}},
+		{id: loc(), alert: false, // high azimuthal gap automatic shouldn't alert
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "automatic", UsedPhaseCount: 22, MagnitudeStationCount: 12, Depth: 10.0, AzimuthalGap: 330, MinimumDistance: 1.0}},
+		{id: loc(), alert: false, // far outside network automatic shouldn't alert
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "automatic", UsedPhaseCount: 22, MagnitudeStationCount: 12, Depth: 10.0, AzimuthalGap: 200, MinimumDistance: 3.0}},
+		//	 combinations of bad quality parameters shouldn't alert
+		{id: loc(), alert: false,
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "automatic", UsedPhaseCount: 22, MagnitudeStationCount: 12, Depth: 10.0, AzimuthalGap: 320, MinimumDistance: 3.0}},
+		{id: loc(), alert: false,
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "automatic", UsedPhaseCount: 22, MagnitudeStationCount: 12, Depth: 0.01, AzimuthalGap: 320, MinimumDistance: 3.0}},
+		//	bad quality parameters but confirmed.  Should all alert.
+		{id: loc(), alert: true,
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "", EvaluationStatus: "confirmed", UsedPhaseCount: 22, MagnitudeStationCount: 12, Depth: 0.01, AzimuthalGap: 200, MinimumDistance: 1.0}},
+		{id: loc(), alert: true,
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "", EvaluationStatus: "confirmed", UsedPhaseCount: 22, MagnitudeStationCount: 12, Depth: 10.0, AzimuthalGap: 330, MinimumDistance: 1.0}},
+		{id: loc(), alert: true,
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "", EvaluationStatus: "confirmed", UsedPhaseCount: 22, MagnitudeStationCount: 12, Depth: 10.0, AzimuthalGap: 200, MinimumDistance: 3.0}},
+		{id: loc(), alert: true,
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "", EvaluationStatus: "confirmed", UsedPhaseCount: 22, MagnitudeStationCount: 12, Depth: 10.0, AzimuthalGap: 320, MinimumDistance: 3.0}},
+		{id: loc(), alert: true,
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "", EvaluationStatus: "confirmed", UsedPhaseCount: 22, MagnitudeStationCount: 12, Depth: 0.01, AzimuthalGap: 320, MinimumDistance: 3.0}},
+		//	bad quality parameters but manual.  Should all alert.
+		{id: loc(), alert: true,
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "manual", UsedPhaseCount: 22, MagnitudeStationCount: 12, Depth: 0.01, AzimuthalGap: 200, MinimumDistance: 1.0}},
+		{id: loc(), alert: true,
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "manual", UsedPhaseCount: 22, MagnitudeStationCount: 12, Depth: 10.0, AzimuthalGap: 330, MinimumDistance: 1.0}},
+		{id: loc(), alert: true,
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "manual", UsedPhaseCount: 22, MagnitudeStationCount: 12, Depth: 10.0, AzimuthalGap: 200, MinimumDistance: 3.0}},
+		{id: loc(), alert: true,
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "manual", UsedPhaseCount: 22, MagnitudeStationCount: 12, Depth: 10.0, AzimuthalGap: 320, MinimumDistance: 3.0}},
+		{id: loc(), alert: true,
+			q: Quake{Time: time.Now().UTC(), Type: "earthquake", EvaluationMode: "manual", UsedPhaseCount: 22, MagnitudeStationCount: 12, Depth: 0.01, AzimuthalGap: 320, MinimumDistance: 3.0}},
+	}
+
+	for _, v := range in {
+		alert, _ := v.q.Alert()
+
+		if alert != v.alert {
+			t.Errorf("%s incorrect alert quality got %t expected %t", v.id, alert, v.alert)
+		}
+	}
+
+	for _, v := range in {
+		v.q.Time = v.q.Time.Add(time.Minute * -61)
+
+		alert, _ := v.q.Alert()
+
+		if alert != false {
+			t.Errorf("%s expected false alert quality any old event", v.id)
+		}
+	}
+}
+
+func loc() string {
+	_, _, l, _ := runtime.Caller(1)
+	return "L" + strconv.Itoa(l)
+}

--- a/sc3ml/sc3ml.go
+++ b/sc3ml/sc3ml.go
@@ -10,11 +10,14 @@ import (
 	"time"
 )
 
-var sc3ml07 = []byte(`<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.7" version="0.7">`)
-var sc3ml08 = []byte(`<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8" version="0.8">`)
-var sc3ml09 = []byte(`<seiscomp xmlns="http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9" version="0.9">`)
+const (
+	sc3ml07 = `http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.7`
+	sc3ml08 = `http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.8`
+	sc3ml09 = `http://geofon.gfz-potsdam.de/ns/seiscomp3-schema/0.9`
+)
 
 type Seiscomp struct {
+	XMLns           string          `xml:"xmlns,attr"`
 	EventParameters EventParameters `xml:"EventParameters"`
 }
 
@@ -141,16 +144,16 @@ type Amplitude struct {
 // Support SC3ML versions are 0.7, 0.8, 0.9
 // Any other versions will result in a error.
 func Unmarshal(b []byte, s *Seiscomp) error {
-	switch {
-	case bytes.Contains(b, sc3ml07):
-	case bytes.Contains(b, sc3ml08):
-	case bytes.Contains(b, sc3ml09):
-	default:
-		return errors.New("unsupported SC3ML version.")
-	}
-
 	if err := xml.Unmarshal(b, s); err != nil {
 		return err
+	}
+
+	switch s.XMLns {
+	case sc3ml07:
+	case sc3ml08:
+	case sc3ml09:
+	default:
+		return errors.New("unsupported SC3ML version")
 	}
 
 	var picks = make(map[string]Pick)


### PR DESCRIPTION
Adds the Quake type and methods to the SC3ML package.  We use these as the haz messaging format and in a number of other projects.

I have a hard time deciding about putting then in the `sc3ml` package or having them in a separate `quake` package.  In a separate `quake` package it's more complicated to create them from an SC3ML file (or there has to be duplicate code).