### PR TITLE
weft pkg for web applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ make clean
 make
 ```
 
+### weft
+
+weft helps with web applications.
+
+
 ### wgs84
 
 wgs84 is for distance, bearing, and locality calculations on the WGS84 ellipsoid.

--- a/weft/errors.go
+++ b/weft/errors.go
@@ -1,0 +1,270 @@
+package weft
+
+const (
+	ErrNotFound = `<html>
+	<head>
+	<title>GeoNet - 404</title>
+	<style>
+	body
+	{
+		font: normal normal 14px/1.3 verdana,arial,helvetica,sans-serif;
+		color: #AEAEAE;
+	}
+	#container
+	{
+		margin: 10% auto;
+		width: 90%;
+		background: #EFEFEF;
+		border: #CCC solid 1px;
+		padding: 2em;
+	}
+	h1
+	{
+		font-size: 3em;
+		color: #AEAEAE;
+	}
+	p
+	{
+		color: #666;
+		text-shadow: #CCC .1em 0px .1em;
+	}
+	.corners-all
+	{
+		-webkit-border-radius: 5px;
+		-moz-border-radius: 5px;
+		border-radius: 5px;
+	}
+	</style>
+	</head>
+	<body>
+	<div id="container" class="corners-all">
+	<h1>Error 404</h1>
+
+	<p><b>404 Page Not Found</b>: '404' is standard notation indicating that the webserver cannot find the page you've requested.</p>
+
+	<p><b>You have selected a page that does not reside at this location</b>, it may have been moved or deleted.
+	There is also the chance of a problem at our end, so it's always worth checking back in a few minutes time.</p>
+
+	<p>Some links are to try are:
+    <ul>
+    <li><a href="https://www.geonet.org.nz">GeoNet Home</a></li>
+    <li><a href="https://www.geonet.org.nz/news">News</a></li>
+    <li><a href="https://www.geonet.org.nz/earthquake/weak">Recent Quakes</a></li>
+    <li><a href="https://www.geonet.org.nz/volcano/ruapehu">Volcanoes</a></li>
+    <li><a href="https://www.geonet.org.nz/volcano/cameras">Volcano Cameras</a></li>
+	</ul>
+	</p>
+
+	<p>If you need more information about this error please contact us directly.</p>
+
+	<p>Many thanks for your patience,<br>
+	- The GeoNet Team.</p>
+	</div>
+	</body>
+	</html>
+	`
+
+	ErrGone = `<html>
+	<head>
+	<title>GeoNet - 410</title>
+	<style>
+	body
+	{
+		font: normal normal 14px/1.3 verdana,arial,helvetica,sans-serif;
+		color: #AEAEAE;
+	}
+	#container
+	{
+		margin: 10% auto;
+		width: 90%;
+		background: #EFEFEF;
+		border: #CCC solid 1px;
+		padding: 2em;
+	}
+	h1
+	{
+		font-size: 3em;
+		color: #AEAEAE;
+	}
+	p
+	{
+		color: #666;
+		text-shadow: #CCC .1em 0px .1em;
+	}
+	.corners-all
+	{
+		-webkit-border-radius: 5px;
+		-moz-border-radius: 5px;
+		border-radius: 5px;
+	}
+	</style>
+	</head>
+	<body>
+	<div id="container" class="corners-all">
+	<h1>Error 410</h1>
+
+	<p><b>410 Page Gone</b>: '410' is standard notation indicating that the page you've requested no longer exists.</p>
+
+	<p>Some links are to try are:
+    <ul>
+    <li><a href="https://www.geonet.org.nz">GeoNet Home</a></li>
+    <li><a href="https://www.geonet.org.nz/news">News</a></li>
+    <li><a href="https://www.geonet.org.nz/earthquake/weak">Recent Quakes</a></li>
+    <li><a href="https://www.geonet.org.nz/volcano/ruapehu">Volcanoes</a></li>
+    <li><a href="https://www.geonet.org.nz/volcano/cameras">Volcano Cameras</a></li>
+	</ul>
+	</p>
+
+	<p>If you need more information about this error please contact us directly.</p>
+
+	<p>Many thanks for your patience,<br>
+	- The GeoNet Team.</p>
+	</div>
+	</body>
+	</html>
+	`
+
+	ErrBadRequest = `<html>
+	<head>
+	<title>GeoNet - 400</title>
+	<style>
+	body
+	{
+		font: normal normal 14px/1.3 verdana,arial,helvetica,sans-serif;
+		color: #AEAEAE;
+	}
+	#container
+	{
+		margin: 10% auto;
+		width: 90%;
+		background: #EFEFEF;
+		border: #CCC solid 1px;
+		padding: 2em;
+	}
+	h1
+	{
+		font-size: 3em;
+		color: #AEAEAE;
+	}
+	p
+	{
+		color: #666;
+		text-shadow: #CCC .1em 0px .1em;
+	}
+	.corners-all
+	{
+		-webkit-border-radius: 5px;
+		-moz-border-radius: 5px;
+		border-radius: 5px;
+	}
+	</style>
+	</head>
+	<body>
+	<div id="container" class="corners-all">
+	<h1>Error 400</h1>
+
+	<p><b>400 Bad Request</b>: '400' is standard notation indicating a bad request, please correct your query and try again.</p>
+
+	<p>If you need more information about this error please contact us directly.</p>
+
+	<p>Many thanks for your patience,<br>
+	- The GeoNet Team.</p>
+	</div>
+	</body>
+	</html>
+	`
+
+	ErrMethodNotAllowed = `<html>
+	<head>
+	<title>GeoNet - 405</title>
+	<style>
+	body
+	{
+		font: normal normal 14px/1.3 verdana,arial,helvetica,sans-serif;
+		color: #AEAEAE;
+	}
+	#container
+	{
+		margin: 10% auto;
+		width: 90%;
+		background: #EFEFEF;
+		border: #CCC solid 1px;
+		padding: 2em;
+	}
+	h1
+	{
+		font-size: 3em;
+		color: #AEAEAE;
+	}
+	p
+	{
+		color: #666;
+		text-shadow: #CCC .1em 0px .1em;
+	}
+	.corners-all
+	{
+		-webkit-border-radius: 5px;
+		-moz-border-radius: 5px;
+		border-radius: 5px;
+	}
+	</style>
+	</head>
+	<body>
+	<div id="container" class="corners-all">
+	<h1>Error 405</h1>
+
+	<p><b>405 Bad Request</b>: '405' is standard notation indicating the HTTP method used is not allowed, please correct your query and try again.</p>
+
+	<p>If you need more information about this error please contact us directly.</p>
+
+	<p>Many thanks for your patience,<br>
+	- The GeoNet Team.</p>
+	</div>
+	</body>
+	</html>
+	`
+
+	ErrServiceUnavailable = `<html>
+	<head>
+	<title>GeoNet 503</title>
+	<style>
+	body
+	{
+		font: normal normal 14px/1.3 verdana,arial,helvetica,sans-serif;
+		color: #AEAEAE;
+	}
+	#container
+	{
+		margin: 10% auto;
+		width: 90%;
+		background: #EFEFEF;
+		border: #CCC solid 1px;
+		padding: 2em;
+	}
+	h1
+	{
+		font-size: 3em;
+		color: #AEAEAE;
+	}
+	p
+	{
+		color: #666;
+		text-shadow: #CCC .1em 0px .1em;
+	}
+	.corners-all
+	{
+		-webkit-border-radius: 5px;
+		-moz-border-radius: 5px;
+		border-radius: 5px;
+	}
+	</style>
+	</head>
+	<body>
+	<div id="container" class="corners-all">
+	<h1>GeoNet Busy</h1>
+	<p>Unfortunately GeoNet systems cannot service your request right now.</p>
+	<p><b>Please try again in a few minutes.</b></p>
+	</div>
+	</body>
+	</html>`
+)

--- a/weft/hander_test.go
+++ b/weft/hander_test.go
@@ -1,0 +1,413 @@
+package weft_test
+
+import (
+	"bytes"
+	"errors"
+	"github.com/GeoNet/kit/weft"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMakeHandler(t *testing.T) {
+	in := []struct {
+		id        string
+		f         weft.RequestHandler
+		code      int
+		surrogate string
+	}{
+		{
+			id: loc(),
+			f: func(r *http.Request, h http.Header, b *bytes.Buffer) error {
+				return nil
+			},
+			code: http.StatusOK,
+		},
+		// returning an error will result in a 503
+		{
+			id: loc(),
+			f: func(r *http.Request, h http.Header, b *bytes.Buffer) error {
+				return errors.New("some error")
+			},
+			code:      http.StatusServiceUnavailable,
+			surrogate: "max-age=10",
+		},
+		// an explicit 503 can also be returned
+		{
+			id: loc(),
+			f: func(r *http.Request, h http.Header, b *bytes.Buffer) error {
+				return weft.StatusError{Code: http.StatusServiceUnavailable, Err: errors.New("some error")}
+			},
+			code:      http.StatusServiceUnavailable,
+			surrogate: "max-age=10",
+		},
+		// 500
+		{
+			id: loc(),
+			f: func(r *http.Request, h http.Header, b *bytes.Buffer) error {
+				return weft.StatusError{Code: http.StatusInternalServerError, Err: errors.New("some error")}
+			},
+			code:      http.StatusInternalServerError,
+			surrogate: "max-age=10",
+		},
+		// 404 - no StatusError.Err needed
+		{
+			id: loc(),
+			f: func(r *http.Request, h http.Header, b *bytes.Buffer) error {
+				return weft.StatusError{Code: http.StatusNotFound}
+			},
+			code:      http.StatusNotFound,
+			surrogate: "max-age=10",
+		},
+		{
+			id: loc(),
+			f: func(r *http.Request, h http.Header, b *bytes.Buffer) error {
+				return weft.StatusError{Code: http.StatusMovedPermanently}
+			},
+			code:      http.StatusMovedPermanently,
+			surrogate: "max-age=86400",
+		},
+		{
+			id: loc(),
+			f: func(r *http.Request, h http.Header, b *bytes.Buffer) error {
+				return weft.StatusError{Code: http.StatusMovedPermanently}
+			},
+			code:      http.StatusMovedPermanently,
+			surrogate: "max-age=86400",
+		},
+		{
+			id: loc(),
+			f: func(r *http.Request, h http.Header, b *bytes.Buffer) error {
+				return weft.StatusError{Code: http.StatusGone}
+			},
+			code:      http.StatusGone,
+			surrogate: "max-age=86400",
+		},
+		{
+			id: loc(),
+			f: func(r *http.Request, h http.Header, b *bytes.Buffer) error {
+				return weft.StatusError{Code: http.StatusBadRequest}
+			},
+			code:      http.StatusBadRequest,
+			surrogate: "max-age=86400",
+		},
+		{
+			id: loc(),
+			f: func(r *http.Request, h http.Header, b *bytes.Buffer) error {
+				return weft.StatusError{Code: http.StatusMethodNotAllowed}
+			},
+			code:      http.StatusMethodNotAllowed,
+			surrogate: "max-age=86400",
+		},
+	}
+
+	// The TextError handler
+	for _, v := range in {
+		handler := weft.MakeHandler(v.f, weft.TextError)
+
+		req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+		w := httptest.NewRecorder()
+		handler(w, req)
+
+		if w.Code != v.code {
+			t.Errorf("%s expected %d got %d", v.id, v.code, w.Code)
+		}
+
+		// only check the content and surrogate for codes that should change the content
+		switch v.code {
+		case http.StatusOK, http.StatusNoContent, http.StatusMovedPermanently, http.StatusSeeOther:
+		default:
+			if w.Code != http.StatusOK {
+				if w.Header().Get("Content-Type") != "text/plain; charset=utf-8" {
+					t.Errorf("%s expected Content-Type %s got %s", v.id, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
+				}
+
+				if w.Header().Get("Surrogate-Control") != v.surrogate {
+					t.Errorf("%s expected Surrogate-Control %s got %s", v.id, v.surrogate, w.Header().Get("Surrogate-Control"))
+				}
+			}
+		}
+	}
+
+	// The HTMLError handler
+	for _, v := range in {
+		handler := weft.MakeHandler(v.f, weft.HTMLError)
+
+		req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+		w := httptest.NewRecorder()
+		handler(w, req)
+
+		if w.Code != v.code {
+			t.Errorf("%s expected %d got %d", v.id, v.code, w.Code)
+		}
+
+		// only check the content and surrogate for codes that should change the content
+		switch v.code {
+		case http.StatusOK, http.StatusNoContent, http.StatusMovedPermanently, http.StatusSeeOther:
+		default:
+			if w.Code != http.StatusOK {
+				if w.Header().Get("Content-Type") != "text/html; charset=utf-8" {
+					t.Errorf("%s: expected Content-Type %s got %s", v.id, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
+				}
+
+				if w.Header().Get("Surrogate-Control") != v.surrogate {
+					t.Errorf("%s: expected Surrogate-Control %s got %s", v.id, v.surrogate, w.Header().Get("Surrogate-Control"))
+				}
+			}
+		}
+	}
+
+	// The UseError handler
+	for _, v := range in {
+		handler := weft.MakeHandler(v.f, weft.UseError)
+
+		req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+		w := httptest.NewRecorder()
+		handler(w, req)
+
+		if w.Code != v.code {
+			t.Errorf("%s expected %d got %d", v.id, v.code, w.Code)
+		}
+
+		// only check the surrogate for codes that should change the content
+		switch v.code {
+		case http.StatusOK, http.StatusNoContent, http.StatusMovedPermanently, http.StatusSeeOther:
+		default:
+			if w.Code != http.StatusOK {
+				if w.Header().Get("Surrogate-Control") != v.surrogate {
+					t.Errorf("%s: expected Surrogate-Control %s got %s", v.id, v.surrogate, w.Header().Get("Surrogate-Control"))
+				}
+			}
+		}
+	}
+}
+
+func TestMakeDirectHandler(t *testing.T) {
+	in := []struct {
+		id        string
+		f         weft.DirectRequestHandler
+		code      int
+		surrogate string
+	}{
+		{
+			id: loc(),
+			f: func(r *http.Request, w http.ResponseWriter) error {
+				w.Write([]byte{})
+				return nil
+			},
+			code: http.StatusOK,
+		},
+		// returning an error will result in a 503
+		{
+			id: loc(),
+			f: func(r *http.Request, w http.ResponseWriter) error {
+				return errors.New("some error")
+			},
+			code:      http.StatusServiceUnavailable,
+			surrogate: "max-age=10",
+		},
+		// an explicit 503 can also be returned
+		{
+			id: loc(),
+			f: func(r *http.Request, w http.ResponseWriter) error {
+				return weft.StatusError{Code: http.StatusServiceUnavailable, Err: errors.New("some error")}
+			},
+			code:      http.StatusServiceUnavailable,
+			surrogate: "max-age=10",
+		},
+		// 500
+		{
+			id: loc(),
+			f: func(r *http.Request, w http.ResponseWriter) error {
+				return weft.StatusError{Code: http.StatusInternalServerError, Err: errors.New("some error")}
+			},
+			code:      http.StatusInternalServerError,
+			surrogate: "max-age=10",
+		},
+		// 404 - no StatusError.Err needed
+		{
+			id: loc(),
+			f: func(r *http.Request, w http.ResponseWriter) error {
+				return weft.StatusError{Code: http.StatusNotFound}
+			},
+			code:      http.StatusNotFound,
+			surrogate: "max-age=10",
+		},
+		{
+			id: loc(),
+			f: func(r *http.Request, w http.ResponseWriter) error {
+				return weft.StatusError{Code: http.StatusMovedPermanently}
+			},
+			code:      http.StatusMovedPermanently,
+			surrogate: "max-age=86400",
+		},
+		{
+			id: loc(),
+			f: func(r *http.Request, w http.ResponseWriter) error {
+				return weft.StatusError{Code: http.StatusMovedPermanently}
+			},
+			code:      http.StatusMovedPermanently,
+			surrogate: "max-age=86400",
+		},
+		{
+			id: loc(),
+			f: func(r *http.Request, w http.ResponseWriter) error {
+				return weft.StatusError{Code: http.StatusGone}
+			},
+			code:      http.StatusGone,
+			surrogate: "max-age=86400",
+		},
+		{
+			id: loc(),
+			f: func(r *http.Request, w http.ResponseWriter) error {
+				return weft.StatusError{Code: http.StatusBadRequest}
+			},
+			code:      http.StatusBadRequest,
+			surrogate: "max-age=86400",
+		},
+		{
+			id: loc(),
+			f: func(r *http.Request, w http.ResponseWriter) error {
+				return weft.StatusError{Code: http.StatusMethodNotAllowed}
+			},
+			code:      http.StatusMethodNotAllowed,
+			surrogate: "max-age=86400",
+		},
+	}
+
+	// The TextError handler
+	for _, v := range in {
+		handler := weft.MakeDirectHandler(v.f, weft.TextError)
+
+		req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+		w := httptest.NewRecorder()
+		handler(w, req)
+
+		if w.Code != v.code {
+			t.Errorf("%s: expected %d got %d", v.id, v.code, w.Code)
+		}
+
+		// only check the content and surrogate for codes that should change the content
+		switch v.code {
+		case http.StatusOK, http.StatusNoContent, http.StatusMovedPermanently, http.StatusSeeOther:
+		default:
+			if w.Code != http.StatusOK {
+				if w.Header().Get("Content-Type") != "text/plain; charset=utf-8" {
+					t.Errorf("%s: expected Content-Type %s got %s", v.id, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
+				}
+
+				if w.Header().Get("Surrogate-Control") != v.surrogate {
+					t.Errorf("%s: expected Surrogate-Control %s got %s", v.id, v.surrogate, w.Header().Get("Surrogate-Control"))
+				}
+			}
+		}
+	}
+
+	// The HTMLError handler
+	for _, v := range in {
+		handler := weft.MakeDirectHandler(v.f, weft.HTMLError)
+
+		req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+		w := httptest.NewRecorder()
+		handler(w, req)
+
+		if w.Code != v.code {
+			t.Errorf("%s: expected %d got %d", v.id, v.code, w.Code)
+		}
+
+		// only check the content and surrogate for codes that should change the content
+		switch v.code {
+		case http.StatusOK, http.StatusNoContent, http.StatusMovedPermanently, http.StatusSeeOther:
+		default:
+			if w.Code != http.StatusOK {
+				if w.Header().Get("Content-Type") != "text/html; charset=utf-8" {
+					t.Errorf("%s: expected Content-Type %s got %s", v.id, "text/plain; charset=utf-8", w.Header().Get("Content-Type"))
+				}
+
+				if w.Header().Get("Surrogate-Control") != v.surrogate {
+					t.Errorf("%s: expected Surrogate-Control %s got %s", v.id, v.surrogate, w.Header().Get("Surrogate-Control"))
+				}
+			}
+		}
+	}
+}
+
+func TestGzip(t *testing.T) {
+	fn := func(r *http.Request, h http.Header, b *bytes.Buffer) error {
+		// write some content to test encoding sniffing and gzip
+		b.Write([]byte(weft.ErrNotFound))
+
+		return nil
+	}
+
+	handler := weft.MakeHandler(fn, weft.TextError)
+
+	// no gzip
+
+	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+	w := httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected %d got %d", http.StatusOK, w.Code)
+	}
+
+	if w.Header().Get("Content-Encoding") != "" {
+		t.Error("did not expected encoded content without Accept-Encoding set")
+	}
+
+	if w.Header().Get("Content-Type") != "text/html; charset=utf-8" {
+		t.Error("incorrect content type")
+	}
+
+	// with gzip
+
+	req = httptest.NewRequest("GET", "http://example.com/foo", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	w = httptest.NewRecorder()
+	handler(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected %d got %d", http.StatusOK, w.Code)
+	}
+
+	if w.Header().Get("Content-Encoding") != "gzip" {
+		t.Error("expected encoded content")
+	}
+
+	if w.Header().Get("Content-Type") != "text/html; charset=utf-8" {
+		t.Error("incorrect content type")
+	}
+}
+
+func TestHandlers(t *testing.T) {
+	in := []struct {
+		id   string
+		f    weft.RequestHandler
+		code int
+	}{
+		{id: loc(), f: weft.NoMatch, code: http.StatusNotFound},
+		{id: loc(), f: weft.Up, code: http.StatusOK},
+		{id: loc(), f: weft.Soh, code: http.StatusOK},
+	}
+
+	for _, v := range in {
+		handler := weft.MakeHandler(v.f, weft.TextError)
+
+		req := httptest.NewRequest("GET", "http://example.com/foo", nil)
+		w := httptest.NewRecorder()
+		handler(w, req)
+
+		if w.Code != v.code {
+			t.Errorf("expected %d got %d", v.code, w.Code)
+		}
+
+		req = httptest.NewRequest("POST", "http://example.com/foo", nil)
+		w = httptest.NewRecorder()
+		handler(w, req)
+
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected %d got %d", http.StatusMethodNotAllowed, w.Code)
+		}
+	}
+}

--- a/weft/handlers.go
+++ b/weft/handlers.go
@@ -1,0 +1,407 @@
+package weft
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"github.com/GeoNet/kit/metrics"
+	"net/http"
+	"reflect"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+var bufferPool = sync.Pool{
+	New: func() interface{} {
+		var b bytes.Buffer
+		return &b
+	},
+}
+
+var logger Logger = discarder{}
+
+// Compressible types from https://www.fastly.com/blog/new-gzip-settings-and-deciding-what-compress
+var compressibleMimes = map[string]bool{
+	"text/html":                     true,
+	"text/html; charset=utf-8":      true,
+	"application/x-javascript":      true,
+	"text/css":                      true,
+	"application/javascript":        true,
+	"text/javascript":               true,
+	"text/plain":                    true,
+	"text/xml":                      true,
+	"application/json":              true,
+	"application/vnd.ms-fontobject": true,
+	"application/x-font-opentype":   true,
+	"application/x-font-truetype":   true,
+	"application/x-font-ttf":        true,
+	"application/xml":               true,
+	"font/eot":                      true,
+	"font/opentype":                 true,
+	"font/otf":                      true,
+	"image/svg+xml":                 true,
+	"image/vnd.microsoft.icon":      true,
+	// other types
+	"application/vnd.geo+json": true,
+	"application/cap+xml":      true,
+	"text/csv":                 true,
+}
+
+// RequestHandler should write the response for r into b and adjust h as required.
+type RequestHandler func(r *http.Request, h http.Header, b *bytes.Buffer) error
+
+// DirectRequestHandler allows writing to the http.ResponseWriter directly.
+type DirectRequestHandler func(r *http.Request, w http.ResponseWriter) error
+
+// ErrorHandler should write the error for err into b and adjust h as required.
+// err can be nil
+type ErrorHandler func(err error, h http.Header, b *bytes.Buffer) error
+
+// MakeDirectHandler executes rh.  The caller should write directly to w for success (200) only.
+// In the case of an rh returning an error ErrorHandler is executed and the response written to the client.
+//
+// Responses are counted.  rh is not wrapped with a timer as this includes the write to the client.
+func MakeDirectHandler(rh DirectRequestHandler, eh ErrorHandler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		err := rh(r, w)
+		if err == nil {
+			metrics.StatusOK()
+			return
+		}
+
+		b := bufferPool.Get().(*bytes.Buffer)
+		defer bufferPool.Put(b)
+		b.Reset()
+
+		e := eh(err, w.Header(), b)
+		if e != nil {
+			logger.Printf("setting error: %s", e.Error())
+		}
+
+		if w.Header().Get("Content-Type") == "" && b != nil {
+			w.Header().Set("Content-Type", http.DetectContentType(b.Bytes()))
+		}
+
+		status := Status(err)
+
+		switch status {
+		case http.StatusMovedPermanently:
+			http.Redirect(w, r, err.Error(), http.StatusMovedPermanently)
+			metrics.StatusOK()
+		case http.StatusSeeOther:
+			http.Redirect(w, r, err.Error(), http.StatusSeeOther)
+			metrics.StatusOK()
+		default:
+			w.Header().Add("Vary", "Accept-Encoding")
+
+			if strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") && compressibleMimes[w.Header().Get("Content-Type")] && b.Len() > 20 {
+				w.Header().Set("Content-Encoding", "gzip")
+				gz := gzip.NewWriter(w)
+				defer gz.Close()
+				w.WriteHeader(status)
+				b.WriteTo(gz)
+			} else {
+				w.WriteHeader(status)
+				b.WriteTo(w)
+			}
+		}
+
+		// metrics and logging
+
+		metrics.Request()
+
+		switch status {
+		case http.StatusOK, http.StatusMovedPermanently, http.StatusSeeOther, http.StatusGone, http.StatusNoContent:
+			metrics.StatusOK()
+		case http.StatusBadRequest:
+			metrics.StatusBadRequest()
+		case http.StatusUnauthorized:
+			metrics.StatusUnauthorized()
+		case http.StatusNotFound:
+			metrics.StatusNotFound()
+			logger.Printf("%d %s", status, r.RequestURI)
+		case http.StatusInternalServerError:
+			metrics.StatusInternalServerError()
+			logger.Printf("%d %s %s %s %s", status, r.Method, r.RequestURI, name, err.Error())
+		case http.StatusServiceUnavailable:
+			metrics.StatusServiceUnavailable()
+			logger.Printf("%d %s %s %s %s", status, r.Method, r.RequestURI, name, err.Error())
+		}
+	}
+}
+
+// MakeHandler returns an http.Handler that executes RequestHandler and collects timing information and metrics.
+// In the case of errors ErrorHandler is used to set error content for the client.
+// 50x errors are logged.
+func MakeHandler(rh RequestHandler, eh ErrorHandler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		b := bufferPool.Get().(*bytes.Buffer)
+		defer bufferPool.Put(b)
+		b.Reset()
+
+		// run the RequestHandler with timing.  If this returns an error then use the
+		// ErrorHandler to set the error content and header.
+
+		t := metrics.Start()
+
+		err := rh(r, w.Header(), b)
+		if err != nil {
+			e := eh(err, w.Header(), b)
+			if e != nil {
+				logger.Printf("setting error: %s", e.Error())
+			}
+		}
+
+		t.Stop()
+
+		// serve the content (which could now be error content).  Gzipping if required.
+
+		if w.Header().Get("Content-Type") == "" && b != nil {
+			w.Header().Set("Content-Type", http.DetectContentType(b.Bytes()))
+		}
+
+		status := Status(err)
+
+		switch status {
+		case http.StatusMovedPermanently:
+			http.Redirect(w, r, err.Error(), http.StatusMovedPermanently)
+			metrics.StatusOK()
+		case http.StatusSeeOther:
+			http.Redirect(w, r, err.Error(), http.StatusSeeOther)
+			metrics.StatusOK()
+		default:
+			w.Header().Add("Vary", "Accept-Encoding")
+
+			if strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") && compressibleMimes[w.Header().Get("Content-Type")] && b.Len() > 20 {
+				w.Header().Set("Content-Encoding", "gzip")
+				gz := gzip.NewWriter(w)
+				defer gz.Close()
+				w.WriteHeader(status)
+				b.WriteTo(gz)
+			} else {
+				w.WriteHeader(status)
+				b.WriteTo(w)
+			}
+		}
+
+		// metrics and logging
+
+		name := name(rh)
+
+		t.Track(name + "." + r.Method)
+
+		metrics.Request()
+
+		switch status {
+		case http.StatusOK, http.StatusMovedPermanently, http.StatusSeeOther, http.StatusGone, http.StatusNoContent:
+			metrics.StatusOK()
+		case http.StatusBadRequest:
+			metrics.StatusBadRequest()
+		case http.StatusUnauthorized:
+			metrics.StatusUnauthorized()
+		case http.StatusNotFound:
+			metrics.StatusNotFound()
+			logger.Printf("%d %s", status, r.RequestURI)
+		case http.StatusInternalServerError:
+			metrics.StatusInternalServerError()
+			logger.Printf("%d %s %s %s %s", status, r.Method, r.RequestURI, name, err.Error())
+		case http.StatusServiceUnavailable:
+			metrics.StatusServiceUnavailable()
+			logger.Printf("%d %s %s %s %s", status, r.Method, r.RequestURI, name, err.Error())
+		}
+	}
+}
+
+// TextError writes text errors to b for non nil error.
+// Headers are set for intermediate caches.
+//
+// Implements ErrorHandler
+func TextError(e error, h http.Header, b *bytes.Buffer) error {
+	if b == nil {
+		return errors.New("nil *bytes.Buffer")
+	}
+
+	var err error
+
+	switch Status(e) {
+	case http.StatusOK:
+		return nil
+	case http.StatusNoContent:
+		return nil
+	case http.StatusMovedPermanently:
+		h.Set("Surrogate-Control", "max-age=86400")
+		return nil
+	case http.StatusSeeOther:
+		h.Set("Surrogate-Control", "max-age=86400")
+		return nil
+	case http.StatusGone:
+		h.Set("Surrogate-Control", "max-age=86400")
+		_, err = b.WriteString("this resource no longer exists")
+		h.Set("Content-Type", "text/plain; charset=utf-8")
+		return nil
+	case http.StatusNotFound:
+		b.Reset()
+		h.Set("Surrogate-Control", "max-age=10")
+		h.Set("Content-Type", "text/plain; charset=utf-8")
+		_, err = b.WriteString("not found")
+	case http.StatusBadRequest:
+		b.Reset()
+		h.Set("Surrogate-Control", "max-age=86400")
+		h.Set("Content-Type", "text/plain; charset=utf-8")
+		_, err = b.WriteString("bad request: " + e.Error())
+	case http.StatusMethodNotAllowed:
+		b.Reset()
+		h.Set("Surrogate-Control", "max-age=86400")
+		h.Set("Content-Type", "text/plain; charset=utf-8")
+		_, err = b.WriteString("method not allowed")
+	case http.StatusServiceUnavailable, http.StatusInternalServerError:
+		b.Reset()
+		h.Set("Surrogate-Control", "max-age=10")
+		h.Set("Content-Type", "text/plain; charset=utf-8")
+		_, err = b.WriteString("service unavailable please try again soon")
+	}
+
+	return err
+}
+
+// UseError sets Headers are set for intermediate caches.
+// The content of b is not changed.
+//
+// Implements ErrorHandler
+func UseError(e error, h http.Header, b *bytes.Buffer) error {
+	switch Status(e) {
+	case http.StatusOK:
+	case http.StatusNoContent:
+	case http.StatusMovedPermanently:
+		h.Set("Surrogate-Control", "max-age=86400")
+	case http.StatusSeeOther:
+		h.Set("Surrogate-Control", "max-age=86400")
+	case http.StatusGone:
+		h.Set("Surrogate-Control", "max-age=86400")
+	case http.StatusNotFound:
+		b.Reset()
+		h.Set("Surrogate-Control", "max-age=10")
+	case http.StatusBadRequest:
+		b.Reset()
+		h.Set("Surrogate-Control", "max-age=86400")
+	case http.StatusMethodNotAllowed:
+		b.Reset()
+		h.Set("Surrogate-Control", "max-age=86400")
+	case http.StatusServiceUnavailable, http.StatusInternalServerError:
+		b.Reset()
+		h.Set("Surrogate-Control", "max-age=10")
+	}
+
+	return nil
+}
+
+// HTMLError writes error pages to b for non nil error.
+// Headers are set for intermediate caches.
+//
+// Implements ErrorHandler
+func HTMLError(e error, h http.Header, b *bytes.Buffer) error {
+	if b == nil {
+		return errors.New("nil *bytes.Buffer")
+	}
+
+	var err error
+
+	switch Status(e) {
+	case http.StatusOK:
+		return nil
+	case http.StatusNoContent:
+		return nil
+	case http.StatusMovedPermanently:
+		h.Set("Surrogate-Control", "max-age=86400")
+		return nil
+	case http.StatusSeeOther:
+		h.Set("Surrogate-Control", "max-age=86400")
+		return nil
+	case http.StatusGone:
+		h.Set("Surrogate-Control", "max-age=86400")
+		_, err = b.Write([]byte(ErrGone))
+		h.Set("Content-Type", "text/html; charset=utf-8")
+		return nil
+	case http.StatusNotFound:
+		b.Reset()
+		h.Set("Surrogate-Control", "max-age=10")
+		_, err = b.Write([]byte(ErrNotFound))
+		h.Set("Content-Type", "text/html; charset=utf-8")
+	case http.StatusBadRequest:
+		b.Reset()
+		h.Set("Surrogate-Control", "max-age=86400")
+		_, err = b.Write([]byte(ErrBadRequest))
+		h.Set("Content-Type", "text/html; charset=utf-8")
+	case http.StatusMethodNotAllowed:
+		b.Reset()
+		h.Set("Surrogate-Control", "max-age=86400")
+		_, err = b.Write([]byte(ErrMethodNotAllowed))
+	case http.StatusServiceUnavailable, http.StatusInternalServerError:
+		b.Reset()
+		h.Set("Surrogate-Control", "max-age=10")
+		_, err = b.Write([]byte(ErrServiceUnavailable))
+		h.Set("Content-Type", "text/html; charset=utf-8")
+	}
+
+	return err
+}
+
+// name finds the name of the function f
+func name(f RequestHandler) string {
+	var n string
+	// Find the name of the function f to use as the timer id
+	fn := runtime.FuncForPC(reflect.ValueOf(f).Pointer())
+	if fn != nil {
+		n = fn.Name()
+		i := strings.LastIndex(n, ".")
+		if i > 0 && i+1 < len(n) {
+			n = n[i+1:]
+		}
+	}
+	return n
+}
+
+// NoMatch returns a 404 for GET requests.
+//
+// Implements RequestHandler
+func NoMatch(r *http.Request, h http.Header, b *bytes.Buffer) error {
+	err := CheckQuery(r, []string{"GET"}, []string{}, []string{})
+	if err != nil {
+		return err
+	}
+
+	return StatusError{Code: http.StatusNotFound}
+}
+
+// Up returns a 200 and simple page for GET requests.
+//
+// Implements RequestHandler
+func Up(r *http.Request, h http.Header, b *bytes.Buffer) error {
+	err := CheckQuery(r, []string{"GET"}, []string{}, []string{})
+	if err != nil {
+		return err
+	}
+
+	h.Set("Content-Type", "text/html; charset=utf-8")
+
+	b.Write([]byte("<html><head></head><body>up</body></html>"))
+
+	return nil
+}
+
+// Soh returns a 200 and simple page for GET requests.
+//
+// Implements RequestHandler
+func Soh(r *http.Request, h http.Header, b *bytes.Buffer) error {
+	err := CheckQuery(r, []string{"GET"}, []string{}, []string{})
+	if err != nil {
+		return err
+	}
+
+	h.Set("Content-Type", "text/html; charset=utf-8")
+
+	b.Write([]byte("<html><head></head><body>ok</body></html>"))
+
+	return nil
+}

--- a/weft/weft.go
+++ b/weft/weft.go
@@ -1,0 +1,141 @@
+// weft helps with web applications.
+package weft
+
+import (
+	"errors"
+	"github.com/GeoNet/kit/metrics"
+	"net/http"
+	"strings"
+)
+
+// Logger defines an interface for logging.
+type Logger interface {
+	Printf(string, ...interface{})
+}
+
+type discarder struct {
+}
+
+func (d discarder) Printf(string, ...interface{}) {
+}
+
+// Error represents an error with an associated HTTP status code.
+type Error interface {
+	error
+	Status() int // the HTTP status code for the error.
+}
+
+// StatusError is for errors with HTTP status codes.  If Code is http.StatusBadRequest then Err.Error()
+// should return a message that is suitable for returning to the client.
+// If Code is http.StatusMovedPermanently or http.StatusSeeOther then Err.Error should return the redirect URL.
+type StatusError struct {
+	Code int
+	Err  error
+}
+
+// SetLogger sets the logger used for logging.  If not set log messages are discarded.
+func SetLogger(l Logger) {
+	if l != nil {
+		logger = l
+	}
+}
+
+// DataDog initialises sending metrics to DataDog.
+func DataDog(apiKey, hostName, appName string, logger Logger) {
+	metrics.DataDogHttp(apiKey, hostName, appName, logger)
+}
+
+func (s StatusError) Error() string {
+	if s.Err == nil {
+		return "<nil>"
+	}
+	return s.Err.Error()
+}
+
+func (s StatusError) Status() int {
+	return s.Code
+}
+
+// Status returns the HTTP status code appropriate for err.
+// It returns:
+//   * http.StatusOk if err is nil
+//   * err.Code if err is a StatusErr and Code is set
+//   * otherwise http.StatusServiceUnavailable
+func Status(err error) int {
+	if err == nil {
+		return http.StatusOK
+	}
+
+	switch e := err.(type) {
+	case Error:
+		switch e.Status() {
+		case 0:
+			return http.StatusServiceUnavailable
+		default:
+			return e.Status()
+		}
+
+	default:
+		return http.StatusServiceUnavailable
+	}
+}
+
+/*
+CheckQuery inspects r and makes sure that the method is allowed, that all required query parameters
+are present, and that no more than the required and optional parameters are present.
+*/
+func CheckQuery(r *http.Request, method, required, optional []string) error {
+	var ok bool
+
+	for i := range method {
+		if r.Method == method[i] {
+			ok = true
+		}
+	}
+
+	if !ok {
+		return StatusError{Code: http.StatusMethodNotAllowed, Err: errors.New("method not allowed")}
+	}
+
+	if strings.Contains(r.URL.Path, ";") {
+		return StatusError{Code: http.StatusBadRequest, Err: errors.New("found a cache buster")}
+	}
+
+	v := r.URL.Query()
+
+	if len(required) == 0 && len(optional) == 0 {
+		if len(v) == 0 {
+			return nil
+		} else {
+			return StatusError{Code: http.StatusBadRequest, Err: errors.New("found unexpected query parameters")}
+		}
+	}
+
+	var missing []string
+
+	for _, k := range required {
+		if v.Get(k) == "" {
+			missing = append(missing, k)
+		} else {
+			v.Del(k)
+		}
+	}
+
+	switch len(missing) {
+	case 0:
+	case 1:
+		return StatusError{Code: http.StatusBadRequest, Err: errors.New("missing required query parameter: " + missing[0])}
+	default:
+		return StatusError{Code: http.StatusBadRequest, Err: errors.New("missing required query parameters: " + strings.Join(missing, ", "))}
+	}
+
+	for _, k := range optional {
+		v.Del(k)
+	}
+
+	if len(v) > 0 {
+		return StatusError{Code: http.StatusBadRequest, Err: errors.New("found additional query parameters")}
+	}
+
+	return nil
+}

--- a/weft/weft_test.go
+++ b/weft/weft_test.go
@@ -1,0 +1,92 @@
+package weft_test
+
+import (
+	"errors"
+	"github.com/GeoNet/kit/weft"
+	"net/http"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestStatus(t *testing.T) {
+	in := []struct {
+		id     string
+		err    error
+		status int
+	}{
+		{id: loc(), err: nil, status: http.StatusOK},
+		{id: loc(), err: errors.New("an error"), status: http.StatusServiceUnavailable},
+		{id: loc(), err: weft.StatusError{Err: errors.New("an error")}, status: http.StatusServiceUnavailable},
+		{id: loc(), err: weft.StatusError{Code: http.StatusServiceUnavailable, Err: errors.New("an error")}, status: http.StatusServiceUnavailable},
+		{id: loc(), err: weft.StatusError{Code: http.StatusServiceUnavailable}, status: http.StatusServiceUnavailable},
+		{id: loc(), err: weft.StatusError{Code: http.StatusBadRequest}, status: http.StatusBadRequest},
+		{id: loc(), err: weft.StatusError{Code: http.StatusBadRequest, Err: errors.New("error for the client")}, status: http.StatusBadRequest},
+		{id: loc(), err: weft.StatusError{Code: http.StatusMethodNotAllowed}, status: http.StatusMethodNotAllowed},
+	}
+
+	for _, v := range in {
+		if s := weft.Status(v.err); s != v.status {
+			t.Errorf("%s expected status %d got %d", v.id, v.status, s)
+		}
+	}
+}
+
+func TestCheckQuery(t *testing.T) {
+	in := []struct {
+		id                 string
+		url                string
+		required, optional []string
+		status             int
+	}{
+		{id: loc(), url: "http://test.com", required: []string{}, optional: []string{}, status: http.StatusOK},
+		{id: loc(), url: "http://test.com", required: []string{}, optional: []string{"optional"}, status: http.StatusOK},
+		{id: loc(), url: "http://test.com?optional=t", required: []string{}, optional: []string{"optional"}, status: http.StatusOK},
+		{id: loc(), url: "http://test.com?optional=t", required: []string{}, optional: []string{"optional", "another"}, status: http.StatusOK},
+		{id: loc(), url: "http://test.com", required: []string{"missing"}, optional: []string{"optional"}, status: http.StatusBadRequest},
+		{id: loc(), url: "http://test.com", required: []string{"missing"}, optional: []string{}, status: http.StatusBadRequest},
+		{id: loc(), url: "http://test.com?required=t", required: []string{"required"}, optional: []string{}, status: http.StatusOK},
+		{id: loc(), url: "http://test.com?required=t", required: []string{"required"}, optional: []string{"optional"}, status: http.StatusOK},
+		{id: loc(), url: "http://test.com?required=t&optional=t", required: []string{"required"}, optional: []string{"optional"}, status: http.StatusOK},
+		{id: loc(), url: "http://test.com?required=t&optional=t&extra=t", required: []string{"required"}, optional: []string{"optional"}, status: http.StatusBadRequest},
+	}
+
+	for _, v := range in {
+		r, err := http.NewRequest("GET", v.url, nil)
+		if err != nil {
+			t.Errorf("%s parsing URL: %s", v.id, err.Error())
+		}
+
+		if s := weft.Status(weft.CheckQuery(r, []string{"GET"}, v.required, v.optional)); s != v.status {
+			t.Errorf("%s expected status %d got %d", v.id, v.status, s)
+		}
+
+		if s := weft.Status(weft.CheckQuery(r, []string{"POST"}, v.required, v.optional)); s != http.StatusMethodNotAllowed {
+			t.Errorf("%s expected status %d got %d", v.id, http.StatusMethodNotAllowed, s)
+		}
+
+		// test with a cache buster added.
+		if !strings.Contains(v.url, "?") {
+			v.url = v.url + "?"
+		}
+
+		r, err = http.NewRequest("GET", v.url+";busta", nil)
+		if err != nil {
+			t.Errorf("%s parsing buster URL: %s", v.id, err.Error())
+		}
+
+		if s := weft.Status(weft.CheckQuery(r, []string{"GET"}, v.required, v.optional)); s != http.StatusBadRequest {
+			t.Errorf("%s buster expected status %d got %d", v.id, http.StatusBadRequest, s)
+		}
+
+		if s := weft.Status(weft.CheckQuery(r, []string{"POST"}, v.required, v.optional)); s != http.StatusMethodNotAllowed {
+			t.Errorf("%s buster expected status %d got %d", v.id, http.StatusMethodNotAllowed, s)
+		}
+	}
+}
+
+func loc() string {
+	_, _, l, _ := runtime.Caller(1)
+	return "L" + strconv.Itoa(l)
+}

--- a/weft/wefttest/wefttest.go
+++ b/weft/wefttest/wefttest.go
@@ -1,0 +1,111 @@
+package wefttest
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// client is used to make requests to the test server.
+var client = &http.Client{Timeout: time.Second * 60}
+
+// Request is for making requests to the server being tested.
+// It describes the Request parameters and elements of the expected response.
+type Request struct {
+	ID             string // An identifier for the request.  Used in error messages.
+	Method         string // Method for the request e.g., "PUT".  Defaults to "GET".
+	Accept         string // Accept header for the request.  Defaults to */*
+	URL            string // The URL to be tested e.g., /path/to/test.  The server can be added at test time.
+	User, Password string // Credentials for basic auth if required.
+	Status         int    // The expected HTTP status code for the request.  Defaults to http.StatusOK (200).
+	Content        string // The expected content type.  Not tested if zero.  A zero Content-Type in the response is an error.
+	Surrogate      string // The expected Surrogate-Control.  Not tested if zero.
+}
+
+type Requests []Request
+
+// L returns the line of code it was called from.
+func L() (loc string) {
+	_, _, l, _ := runtime.Caller(1)
+	return "L" + strconv.Itoa(l)
+}
+
+// DoAll runs all Request in Requests against server and returns for the first non nil error.
+func (r Requests) DoAll(server string) error {
+	for _, v := range r {
+		_, err := v.Do(server)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Do runs the Request and returns a non nil error for responses that
+// do not match the Request (and other error conditions).
+// server is prepended to r.URL if it starts with "/".
+// Also returns the body from the response.
+func (r Request) Do(server string) ([]byte, error) {
+	// Set default values for request
+	if r.Accept == "" {
+		r.Accept = "*/*"
+	}
+
+	if r.Status == 0 {
+		r.Status = http.StatusOK
+	}
+
+	if r.Method == "" {
+		r.Method = "GET"
+	}
+
+	if strings.HasPrefix(r.URL, "/") {
+		r.URL = server + r.URL
+	}
+
+	var req *http.Request
+	var res *http.Response
+	var err error
+
+	if req, err = http.NewRequest(r.Method, r.URL, nil); err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Accept", r.Accept)
+
+	if r.User != "" || r.Password != "" {
+		req.SetBasicAuth(r.User, r.Password)
+	}
+
+	if res, err = client.Do(req); err != nil {
+		return nil, fmt.Errorf("%s %s %s error: %s", r.ID, r.URL, r.Method, err.Error())
+	}
+	defer res.Body.Close()
+
+	if r.Status != res.StatusCode {
+		return nil, fmt.Errorf("%s %s %s got status %d expected %d", r.ID, r.URL, r.Method, res.StatusCode, r.Status)
+	}
+
+	if r.Surrogate != "" {
+		if res.Header.Get("Surrogate-Control") != r.Surrogate {
+			return nil, fmt.Errorf("%s got Surrogate-Control %s expected %s", r.ID, res.Header.Get("Surrogate-Control"), r.Surrogate)
+		}
+	}
+
+	if r.Content != "" {
+		if res.Header.Get("Content-Type") != r.Content {
+			return nil, fmt.Errorf("%s %s %s got Content-Type %s expected %s", r.ID, r.URL, r.Method, res.Header.Get("Content-Type"), r.Content)
+		}
+	}
+
+	if res.Header.Get("Content-Type") == "" {
+		return nil, fmt.Errorf("%s got empty Content-Type header for response", r.ID)
+	}
+
+	return ioutil.ReadAll(res.Body)
+}


### PR DESCRIPTION
add a weft pkg for web applications.  This is based on the (may) internal weft pkgs. 

I've applied this pkg (but not yet vendored it) here:

* https://github.com/gclitheroe/fdsn/tree/wip-kit-weft
* https://github.com/gclitheroe/gloria/tree/wip-metrics-ws

Please could you review this but hold off merging?  I will apply this to some other web projects to make sure the public api still makes sense.


 Compared to .../internal/weft it;

* uses error returns instead of weft.Result.  `func Status(err error) int` can then be used to decide what http status code is returned.  This is based on "Assert errors for behaviour, not type" from https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully and a couple of other blogs.  Returning an error seems "more idiomatic" to me.  FWIW the weft.Result idea was originally from "Simplifying repetitive error handling" https://blog.golang.org/error-handling-and-go
* CheckQuery requires the HTTP method being handled to be listed and returns method not allowed for anything else.
* MakeHandler takes an ErrorHandler function for setting the error response to send back to the client.  This allows error page customisation as required.  There are three concrete implementations for ErrorHandler which should cover all our common cases.
* I added concrete implementations of some of the very common RequestHandlers.