### PR TITLE
Send the http written metric to datadog.

### DIFF
--- a/metrics/ddog_http.go
+++ b/metrics/ddog_http.go
@@ -127,6 +127,12 @@ func dogHttp(apiKey, hostName, appName string, m runtime.MemStats, t []TimerStat
 			Type:   "counter",
 			Host:   hostName,
 		},
+		{
+			Metric: appName + "http.written",
+			Points: []point{[2]float32{now, float32(c.Written)}},
+			Type:   "counter",
+			Host:   hostName,
+		},
 	},
 	}
 


### PR DESCRIPTION
Forgot to actually add the written metric to the JSON that is sent to Data Dog.  This adds it.