### PR TITLE
Updated CSP to allow Google Analytics and Survicate

### DIFF
--- a/weft/handlers.go
+++ b/weft/handlers.go
@@ -270,11 +270,11 @@ func MakeHandler(rh RequestHandler, eh ErrorHandler) http.HandlerFunc {
 func setBestPracticeHeaders(w http.ResponseWriter, r *http.Request) {
 	//Content Security Policy: allow inline styles, but no inline scripts, prevent from clickjacking
 	w.Header().Set("Content-Security-Policy", "default-src 'none'; "+
-		"img-src 'self' *.geonet.org.nz data:; "+
-		"font-src 'self' https://fonts.gstatic.com; "+
+		"img-src 'self' *.geonet.org.nz data: www.google-analytics.com; "+
+		"font-src 'self' https://fonts.gstatic.com https://surveys-static.survicate.com; "+
 		"style-src 'self' 'unsafe-inline' https://*.googleapis.com; "+
-		"script-src 'self' https://cdnjs.cloudflare.com https://www.google.com https://www.gstatic.com; "+
-		"connect-src 'self' https://*.geonet.org.nz; "+
+		"script-src 'self' https://cdnjs.cloudflare.com https://www.google.com https://www.gstatic.com https://*.survicate.com https://www.googletagmanager.com;"+
+		"connect-src 'self' https://*.geonet.org.nz https://*.survicate.com;"+
 		"frame-src 'self' https://www.youtube.com https://www.google.com; "+
 		"form-action 'self'; "+
 		"base-uri 'none'; "+


### PR DESCRIPTION
## Proposed Changes

Changes proposed in this pull request:

- Added URLs to allow scripts from Survicate.com and GoogleTagManager.com (for Google analytics). These are needed to gather user feedback and data on how users are using the GeoNet website in order to make improvements in an upcoming website update.

## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.
