### PR TITLE
Update CSP to just use Google Analytics, not Google Tag Manager.

### DIFF
--- a/weft/handlers.go
+++ b/weft/handlers.go
@@ -270,10 +270,10 @@ func MakeHandler(rh RequestHandler, eh ErrorHandler) http.HandlerFunc {
 func setBestPracticeHeaders(w http.ResponseWriter, r *http.Request) {
 	//Content Security Policy: allow inline styles, but no inline scripts, prevent from clickjacking
 	w.Header().Set("Content-Security-Policy", "default-src 'none'; "+
-		"img-src 'self' *.geonet.org.nz data: www.google-analytics.com; "+
+		"img-src 'self' *.geonet.org.nz data: https://www.google-analytics.com;"+
 		"font-src 'self' https://fonts.gstatic.com https://surveys-static.survicate.com; "+
 		"style-src 'self' 'unsafe-inline' https://*.googleapis.com; "+
-		"script-src 'self' https://cdnjs.cloudflare.com https://www.google.com https://www.gstatic.com https://*.survicate.com https://www.googletagmanager.com;"+
+		"script-src 'self' https://cdnjs.cloudflare.com https://www.google.com https://www.gstatic.com https://*.survicate.com https://www.google-analytics.com;"+
 		"connect-src 'self' https://*.geonet.org.nz https://*.survicate.com;"+
 		"frame-src 'self' https://www.youtube.com https://www.google.com; "+
 		"form-action 'self'; "+


### PR DESCRIPTION
## Proposed Changes

Changes proposed in this pull request:

Google Tag Manager lets you manage various JS tracking codes, including the Google Analytics tracking code, which would allow us to capture more user metrics. However, it **requires** the CSP to contain 'unsafe-inline' in the script-src directive. This would be a security risk, so sticking to just the Google Analytics tracking is the best way forward.

## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.