### PR TITLE
fix nzmap bug

### DIFF
--- a/map180/nzmap/nzmap.go
+++ b/map180/nzmap/nzmap.go
@@ -164,7 +164,7 @@ func (pts Points) Medium(b *bytes.Buffer) {
 			yi, yf := math.Modf(v.Latitude*10 + 480.0)
 			y := int(yi)
 
-			if x >= 0 && x < 150 && y >= 0 && y < 140 {
+			if x >= 0 && x < 150 && y >= 0 && y < 139 {
 				p = nzMediumPts[int(x)][y]
 				pp = nzMediumPts[x+1][y+1]
 				pts[i].x = p.x + int(float64(pp.x-p.x)*xf)


### PR DESCRIPTION
## Proposed Changes

Resolves #GeoNet/www-geonet/issues/748

Changes proposed in this pull request:

- Fix `array index out of bound exception` which causes crash in `www-geonet`


## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*