### PR TITLE
Strict csp browser compatibility update…

### DIFF
--- a/weft/handlers.go
+++ b/weft/handlers.go
@@ -303,15 +303,13 @@ func setBestPracticeHeaders(w http.ResponseWriter, r *http.Request, customCsp ma
 		}
 		csp.WriteString(k)
 		csp.WriteString(" ")
+
 		if k == "script-src" && nonce != "" { //add nonce to CSP
-			csp.WriteString(fmt.Sprintf("'nonce-%s' 'strict-dynamic';", nonce))
-		} else {
-			csp.WriteString(s)
-			csp.WriteString("; ")
+			csp.WriteString(fmt.Sprintf(" 'nonce-%s' 'strict-dynamic' ", nonce))
 		}
+		csp.WriteString(s)
+		csp.WriteString("; ")
 	}
-	//Content Security Policy: allow inline styles, but no inline scripts, prevent from clickjacking
-	//The hash in script-src is to allow the inline JavaScript that the SurveyMonkey popup inserts as part of its IFrame.
 	w.Header().Set("Content-Security-Policy", csp.String())
 	w.Header().Set("X-Frame-Options", "DENY")
 	w.Header().Set("X-XSS-Protection", "1; mode=block")


### PR DESCRIPTION
Minor changes for old browser compatibility as `nonce` `strict-dynamic` directive will be ignored in old browsers  that don't support CSP3 as commented [here](https://github.com/GeoNet/www-geonet/issues/795#issuecomment-617706346).

## Proposed Changes

Changes proposed in this pull request:


## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*