### PR TITLE
wefttest: add CSP check for response headers

### DIFF
--- a/weft/handlers.go
+++ b/weft/handlers.go
@@ -72,7 +72,7 @@ var defaultCsp = map[string]string{
 
 var strictCsp = map[string]string{
 	"default-src":     "'none'",
-	"img-src":         "'self' ",
+	"img-src":         "'self'",
 	"font-src":        "'none'",
 	"style-src":       "'none'",
 	"script-src":      "'none'",
@@ -323,7 +323,7 @@ func setBestPracticeHeaders(w http.ResponseWriter, r *http.Request, customCsp ma
 		csp.WriteString(k)
 		csp.WriteString(" ")
 
-		if k == "script-src" && nonce != "" { //add nonce to CSP
+		if k == "script-src" && nonce != "" && s != "'none'" { //add nonce to CSP
 			csp.WriteString(fmt.Sprintf(" 'nonce-%s' 'strict-dynamic' ", nonce))
 		}
 		csp.WriteString(s)

--- a/weft/wefttest/wefttest.go
+++ b/weft/wefttest/wefttest.go
@@ -31,7 +31,7 @@ type Request struct {
 	Status         int               // The expected HTTP status code for the request.  Defaults to http.StatusOK (200).
 	Content        string            // The expected content type.  Not tested if zero.  A zero Content-Type in the response is an error.
 	Surrogate      string            // The expected Surrogate-Control.  Not tested if zero.
-	CSP            map[string]string //expected content-security-policy
+	CSP            map[string]string // expected header for content-security-policy
 }
 
 type Requests []Request

--- a/weft/wefttest/wefttest.go
+++ b/weft/wefttest/wefttest.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -16,18 +17,21 @@ var client = &http.Client{Timeout: time.Second * 60}
 
 var httpMethods = []string{"GET", "DELETE", "POST", "PUT", "HEAD", "CONNECT", "OPTIONS", "TRACE", "PATCH"}
 
+var noncePattern = "^'nonce-[A-Za-z0-9+/=]{20}' 'strict-dynamic' %s$"
+
 // Request is for making requests to the server being tested.
 // It describes the Request parameters and elements of the expected response.
 type Request struct {
-	ID             string // An identifier for the request.  Used in error messages.
-	Method         string // Method for the request e.g., "PUT".  Defaults to "GET".
-	PostBody       []byte // Request body.
-	Accept         string // Accept header for the request.  Defaults to */*
-	URL            string // The URL to be tested e.g., /path/to/test.  The server can be added at test time.
-	User, Password string // Credentials for basic auth if required.
-	Status         int    // The expected HTTP status code for the request.  Defaults to http.StatusOK (200).
-	Content        string // The expected content type.  Not tested if zero.  A zero Content-Type in the response is an error.
-	Surrogate      string // The expected Surrogate-Control.  Not tested if zero.
+	ID             string            // An identifier for the request.  Used in error messages.
+	Method         string            // Method for the request e.g., "PUT".  Defaults to "GET".
+	PostBody       []byte            // Request body.
+	Accept         string            // Accept header for the request.  Defaults to */*
+	URL            string            // The URL to be tested e.g., /path/to/test.  The server can be added at test time.
+	User, Password string            // Credentials for basic auth if required.
+	Status         int               // The expected HTTP status code for the request.  Defaults to http.StatusOK (200).
+	Content        string            // The expected content type.  Not tested if zero.  A zero Content-Type in the response is an error.
+	Surrogate      string            // The expected Surrogate-Control.  Not tested if zero.
+	CSP            map[string]string //expected content-security-policy
 }
 
 type Requests []Request
@@ -117,7 +121,61 @@ func (r Request) Do(server string) ([]byte, error) {
 		return nil, fmt.Errorf("%s got empty Content-Type header for response", r.ID)
 	}
 
+	if r.CSP != nil { //check response csp
+		cspString := res.Header.Get(("content-security-policy"))
+		if err := checkCSP(parseCspContent(cspString), r.CSP); err != nil {
+			//fmt.Println("## error URL", r.URL, cspString)
+			return nil, fmt.Errorf("%s got error content-security-policy header url %s, \n error: %s", r.ID, r.URL, err.Error())
+		}
+	}
+
 	return ioutil.ReadAll(res.Body)
+}
+
+/**
+ * convert CSP string to map
+ */
+func parseCspContent(content string) map[string]string {
+	cspArray := strings.Split(content, ";")
+	cspMap := make(map[string]string)
+	for _, csp := range cspArray {
+		s := strings.TrimSpace(csp)
+		index := strings.Index(s, " ")
+		if index > 0 {
+			key := s[0:index]
+			val := s[index+1:]
+			cspMap[key] = strings.TrimSpace(val)
+		}
+	}
+	return cspMap
+}
+
+/**
+ * check response CSP match expected
+ */
+func checkCSP(respCsp, expectedCsp map[string]string) error {
+	for k, v := range expectedCsp {
+		v1 := respCsp[k]
+		if k == "script-src" && strings.Contains(v1, "nonce-") { //check nonce
+			pattern := fmt.Sprintf(noncePattern, v)
+			if !patternMatch(pattern, v1) {
+				return fmt.Errorf("## Response CSP %s=%s doesn't match expected %s=%s", k, v1, k, v)
+			}
+		} else {
+			if v1 != v {
+				return fmt.Errorf("## Response CSP %s=%s doesn't match expected %s=%s", k, v1, k, v)
+			}
+		}
+	}
+	return nil
+}
+
+func patternMatch(pattern string, str string) bool {
+	match, err := regexp.MatchString(pattern, str)
+	if err != nil {
+		return false
+	}
+	return match
 }
 
 // MethodNotAllowed tests r that all HTTP methods that are not in allowed return an http.StatusMethodNotAllowed.

--- a/weft/wefttest/wefttest_test.go
+++ b/weft/wefttest/wefttest_test.go
@@ -16,7 +16,8 @@ const (
 	maxAge86400 = "max-age=86400"
 )
 
-var defaultCsp = map[string]string{
+//expected csp header for normal responses
+var normalCspHeader = map[string]string{
 	"default-src":     "'none'",
 	"img-src":         "'self' *.geonet.org.nz data: https://www.google-analytics.com https://stats.g.doubleclick.net",
 	"font-src":        "'self' https://fonts.gstatic.com",
@@ -30,7 +31,8 @@ var defaultCsp = map[string]string{
 	"object-src":      "'none'",
 }
 
-var strictCsp = map[string]string{
+//expected csp header for error responses
+var errorCspHeader = map[string]string{
 	"default-src":     "'none'",
 	"img-src":         "'self'",
 	"font-src":        "'none'",
@@ -99,7 +101,7 @@ func TestRoutes(t *testing.T) {
 	errors := 0
 
 	for _, v := range routes {
-		v.CSP = defaultCsp
+		v.CSP = normalCspHeader
 		_, err := v.Do(ts.URL)
 		if err != nil {
 			t.Errorf("TestRoutes %s", err.Error())
@@ -122,7 +124,7 @@ func TestMethodNotAllowed(t *testing.T) {
 	for _, v := range routes {
 		v.Surrogate = maxAge86400
 		v.Content = errContent
-		v.CSP = strictCsp //strictCsp for error response
+		v.CSP = errorCspHeader //strictCsp for error response
 
 		i, err := v.MethodNotAllowed(ts.URL, []string{"GET"})
 		if err != nil {
@@ -146,7 +148,7 @@ func TestExtraParameter(t *testing.T) {
 	for _, v := range routes {
 		v.Surrogate = maxAge86400
 		v.Content = errContent
-		v.CSP = strictCsp //strictCsp for error response
+		v.CSP = errorCspHeader //strictCsp for error response
 
 		err := v.ExtraParameter(ts.URL, "extra", "parameter")
 		if err != nil {
@@ -173,7 +175,7 @@ func TestFuzzQuery(t *testing.T) {
 	for _, v := range routes {
 		v.Surrogate = maxAge86400
 		v.Content = errContent
-		v.CSP = strictCsp //strictCsp for error response
+		v.CSP = errorCspHeader //strictCsp for error response
 		i, err := v.FuzzQuery(ts.URL, wt.FuzzValues)
 		if err != nil {
 			t.Errorf("TestFuzzQuery %s", err.Error())


### PR DESCRIPTION
CSP headers are set for different route paths, and have not been unit tested before, unit routes test on response headers can be useful in detecting errors in #81

## Proposed Changes



Changes proposed in this pull request:

- Add functionality to check CSP for response headers for routes unit tests


## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*