### PR TITLE
update sqs add GetQueueUrl by name

### DIFF
--- a/aws/sqs/sqs.go
+++ b/aws/sqs/sqs.go
@@ -144,3 +144,18 @@ func (s *SQS) SendFifoMessage(queue, group, dedupe string, msg []byte) (string, 
 	}
 	return "", nil
 }
+
+// GetQueueUrl returns an AWS SQS queue URL given its name.
+func (s *SQS) GetQueueUrl(name string) (string, error) {
+	params := sqs.GetQueueUrlInput{
+		QueueName: aws.String(name),
+	}
+	output, err := s.client.GetQueueUrl(context.TODO(), &params)
+	if err != nil {
+		return "", err
+	}
+	if url := output.QueueUrl; url != nil {
+		return aws.ToString(url), nil
+	}
+	return "", nil
+}


### PR DESCRIPTION
## Proposed Changes

- Convenient method to obtain SQS url from queue name, used for [shakemap](https://github.com/GeoNet/terraform-aws/blob/main/environments/dev/shakemap-rapid/outputs.tf#L17) related cross application queues where only queue names are available from remote state output 

Changes proposed in this pull request:



## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*