### PR TITLE
Optional DDOG_DUMP to dump metric when DDOG_API_KEY is absent.

### DIFF
--- a/metrics/ddog_http.go
+++ b/metrics/ddog_http.go
@@ -18,7 +18,7 @@ func DataDogHttp(apiKey, hostName, appName string, logger Logger) {
 		logger = discarder{}
 	}
 
-	if apiKey == "" {
+	if apiKey == "" && dumpMetric {
 		logger.Printf("empty env var DDOG_API_KEY metrics will be logged")
 	}
 
@@ -38,7 +38,7 @@ func DataDogHttp(apiKey, hostName, appName string, logger Logger) {
 				if err != nil {
 					logger.Printf("error sending metrics to datadog for %s %s %s", hostName, appName, err.Error())
 				}
-			} else {
+			} else if dumpMetric {
 				logger.Printf("%s %s", hostName, appName)
 				logger.Printf("%+v", m)
 				logger.Printf("%+v", ReadTimers())

--- a/metrics/ddog_msg.go
+++ b/metrics/ddog_msg.go
@@ -14,6 +14,7 @@ import (
 const dogUrl = "https://app.datadoghq.com/api/v1/series"
 
 var client = &http.Client{}
+var dumpMetric = (os.Getenv("DDOG_DUMP") == "1")
 
 type point [2]float64
 
@@ -50,7 +51,7 @@ func DataDogMsg(apiKey, hostName, appName string, logger Logger) {
 		logger = discarder{}
 	}
 
-	if apiKey == "" {
+	if apiKey == "" && dumpMetric {
 		logger.Printf("empty apiKey metrics will be logged")
 	}
 
@@ -70,7 +71,7 @@ func DataDogMsg(apiKey, hostName, appName string, logger Logger) {
 				if err != nil {
 					logger.Printf("error sending metrics to datadog for %s %s %s", hostName, appName, err.Error())
 				}
-			} else {
+			} else if dumpMetric {
 				logger.Printf("%s %s", hostName, appName)
 				logger.Printf("%+v", m)
 				logger.Printf("%+v", ReadTimers())
@@ -87,7 +88,7 @@ func DataDogMsgSync(apiKey, hostName, appName string, logger Logger) {
 		logger = discarder{}
 	}
 
-	if apiKey == "" {
+	if apiKey == "" && dumpMetric {
 		logger.Printf("empty apiKey metrics will be logged")
 	}
 
@@ -101,7 +102,7 @@ func DataDogMsgSync(apiKey, hostName, appName string, logger Logger) {
 		if err != nil {
 			logger.Printf("error sending metrics to datadog for %s %s %s", hostName, appName, err.Error())
 		}
-	} else {
+	} else if dumpMetric {
 		logger.Printf("%s %s", hostName, appName)
 		logger.Printf("%+v", m)
 		logger.Printf("%+v", ReadTimers())


### PR DESCRIPTION
## Proposed Changes

Changes proposed in this pull request:

- Silent the redundant Datadog metric dump by default when DDOG_API_KEY is not set. Set env `DDOG_DUMP=1` to enable the dump.
-
-

## Production Changes

The following production changes are required to deploy these changes:

- Will affect later built instances without DDOG_API_KEY set, but it's expected.
- 

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*