### PR TITLE
Update default CSP for Google Analytics version 4

### DIFF
--- a/weft/handlers.go
+++ b/weft/handlers.go
@@ -58,11 +58,11 @@ var compressibleMimes = map[string]bool{
 
 var defaultCsp = map[string]string{
 	"default-src":     "'none'",
-	"img-src":         "'self' *.geonet.org.nz data: https://www.google-analytics.com https://stats.g.doubleclick.net",
+	"img-src":         "'self' *.geonet.org.nz data: https://*.google-analytics.com https://*.googletagmanager.com",
 	"font-src":        "'self' https://fonts.gstatic.com",
 	"style-src":       "'self'",
-	"script-src":      "'self'",
-	"connect-src":     "'self' https://*.geonet.org.nz https://www.google-analytics.com https://stats.g.doubleclick.net",
+	"script-src":      "'self' https://*.googletagmanager.com",
+	"connect-src":     "'self' https://*.geonet.org.nz https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com",
 	"frame-src":       "'self' https://www.youtube.com https://www.google.com",
 	"form-action":     "'self'",
 	"base-uri":        "'none'",
@@ -545,4 +545,24 @@ func Soh(r *http.Request, h http.Header, b *bytes.Buffer) error {
 	b.Write([]byte("<html><head></head><body>ok</body></html>"))
 
 	return nil
+}
+
+// ReturnDefaultCSP returns the default Content Security Policy used
+// by handlers. This is a copy of the map, so can be changed safely if needed.
+func ReturnDefaultCSP() map[string]string {
+	copy := make(map[string]string)
+	for k, v := range defaultCsp {
+		copy[k] = v
+	}
+	return copy
+}
+
+// ReturnStrictCSP returns the strict Content Security Policy used by
+// error handlers. This is a copy of the map, so can be changed safely if needed.
+func ReturnStrictCSP() map[string]string {
+	copy := make(map[string]string)
+	for k, v := range strictCsp {
+		copy[k] = v
+	}
+	return copy
 }

--- a/weft/handlers.go
+++ b/weft/handlers.go
@@ -5,13 +5,14 @@ import (
 	"compress/gzip"
 	"errors"
 	"fmt"
-	"github.com/GeoNet/kit/metrics"
 	"io/ioutil"
 	"net/http"
 	"reflect"
 	"runtime"
 	"strings"
 	"sync"
+
+	"github.com/GeoNet/kit/metrics"
 )
 
 var bufferPool = sync.Pool{
@@ -161,8 +162,7 @@ func MakeHandlerWithCsp(rh RequestHandler, eh ErrorHandler, customCsp map[string
 			if e != nil {
 				logger.Printf("2 error from error handler: %s", e.Error())
 			}
-			//set strict csp for error page
-			setBestPracticeHeaders(w, r, strictCsp, "")
+			setBestPracticeHeaders(w, r, defaultCsp, "")
 		} else {
 			setBestPracticeHeaders(w, r, customCsp, "")
 		}
@@ -211,8 +211,7 @@ func MakeHandlerWithCspNonce(rh RequestHandlerWithNonce, eh ErrorHandler, custom
 			if e != nil {
 				logger.Printf("2 error from error handler: %s", e.Error())
 			}
-			//set strict csp for error page
-			setBestPracticeHeaders(w, r, strictCsp, nonce)
+			setBestPracticeHeaders(w, r, defaultCsp, nonce)
 		} else {
 			setBestPracticeHeaders(w, r, customCsp, nonce)
 		}

--- a/weft/wefttest/wefttest_test.go
+++ b/weft/wefttest/wefttest_test.go
@@ -21,7 +21,7 @@ const (
 var normalCspHeader = weft.ReturnDefaultCSP()
 
 //expected csp header for error responses
-var errorCspHeader = weft.ReturnStrictCSP()
+var errorCspHeader = weft.ReturnDefaultCSP()
 
 // test server and handlers for running the tests
 

--- a/weft/wefttest/wefttest_test.go
+++ b/weft/wefttest/wefttest_test.go
@@ -3,12 +3,13 @@ package wefttest_test
 import (
 	"bytes"
 	"fmt"
-	"github.com/GeoNet/kit/weft"
-	wt "github.com/GeoNet/kit/weft/wefttest"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+
+	"github.com/GeoNet/kit/weft"
+	wt "github.com/GeoNet/kit/weft/wefttest"
 )
 
 const (
@@ -17,34 +18,10 @@ const (
 )
 
 //expected csp header for normal responses
-var normalCspHeader = map[string]string{
-	"default-src":     "'none'",
-	"img-src":         "'self' *.geonet.org.nz data: https://www.google-analytics.com https://stats.g.doubleclick.net",
-	"font-src":        "'self' https://fonts.gstatic.com",
-	"style-src":       "'self'",
-	"script-src":      "'self'",
-	"connect-src":     "'self' https://*.geonet.org.nz https://www.google-analytics.com https://stats.g.doubleclick.net",
-	"frame-src":       "'self' https://www.youtube.com https://www.google.com",
-	"form-action":     "'self'",
-	"base-uri":        "'none'",
-	"frame-ancestors": "'self'",
-	"object-src":      "'none'",
-}
+var normalCspHeader = weft.ReturnDefaultCSP()
 
 //expected csp header for error responses
-var errorCspHeader = map[string]string{
-	"default-src":     "'none'",
-	"img-src":         "'self'",
-	"font-src":        "'none'",
-	"style-src":       "'none'",
-	"script-src":      "'none'",
-	"connect-src":     "'none'",
-	"frame-src":       "'none'",
-	"form-action":     "'none'",
-	"base-uri":        "'none'",
-	"frame-ancestors": "'none'",
-	"object-src":      "'none'",
-}
+var errorCspHeader = weft.ReturnStrictCSP()
 
 // test server and handlers for running the tests
 


### PR DESCRIPTION
Reference: https://github.com/GeoNet/tickets/issues/10813

Changes proposed in this pull request:

- Update default CSP based on [Google Analytics v4 docs](https://developers.google.com/tag-platform/tag-manager/web/csp#google_analytics_4_google_analytics).
- Add exported helper functions to return the default and strict CSPs to prevent duplication.

## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*