### PR TITLE
Remove unneeded url from CSP, strict CSP.

### DIFF
--- a/weft/handlers.go
+++ b/weft/handlers.go
@@ -62,7 +62,7 @@ var defaultCsp = map[string]string{
 	"img-src":         "'self' *.geonet.org.nz data: https://*.google-analytics.com https://*.googletagmanager.com",
 	"font-src":        "'self' https://fonts.gstatic.com",
 	"style-src":       "'self'",
-	"script-src":      "'self' https://*.googletagmanager.com",
+	"script-src":      "'self'",
 	"connect-src":     "'self' https://*.geonet.org.nz https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com",
 	"frame-src":       "'self' https://www.youtube.com https://www.google.com",
 	"form-action":     "'self'",

--- a/weft/handlers.go
+++ b/weft/handlers.go
@@ -71,20 +71,6 @@ var defaultCsp = map[string]string{
 	"object-src":      "'none'",
 }
 
-var strictCsp = map[string]string{
-	"default-src":     "'none'",
-	"img-src":         "'self'",
-	"font-src":        "'none'",
-	"style-src":       "'none'",
-	"script-src":      "'none'",
-	"connect-src":     "'none'",
-	"frame-src":       "'none'",
-	"form-action":     "'none'",
-	"base-uri":        "'none'",
-	"frame-ancestors": "'none'",
-	"object-src":      "'none'",
-}
-
 /**
  * RequestHandler should write the response for r into b and adjust h as required
  */
@@ -551,16 +537,6 @@ func Soh(r *http.Request, h http.Header, b *bytes.Buffer) error {
 func ReturnDefaultCSP() map[string]string {
 	copy := make(map[string]string)
 	for k, v := range defaultCsp {
-		copy[k] = v
-	}
-	return copy
-}
-
-// ReturnStrictCSP returns the strict Content Security Policy used by
-// error handlers. This is a copy of the map, so can be changed safely if needed.
-func ReturnStrictCSP() map[string]string {
-	copy := make(map[string]string)
-	for k, v := range strictCsp {
 		copy[k] = v
 	}
 	return copy

--- a/weft/wefttest/wefttest.go
+++ b/weft/wefttest/wefttest.go
@@ -162,7 +162,8 @@ func checkCSP(respCsp, expectedCsp map[string]string) error {
 	for k, v := range expectedCsp {
 		v1 := respCsp[k]
 		if k == "script-src" && strings.Contains(v1, "nonce-") { //check nonce
-			pattern := fmt.Sprintf(noncePattern, v)
+			escapedV := strings.Replace(v, "*", "\\*", -1) // escape wildcards to avoid regex clash
+			pattern := fmt.Sprintf(noncePattern, escapedV)
 			if !patternMatch(pattern, v1) {
 				return fmt.Errorf("## Response CSP %s=%s doesn't match expected %s=%s", k, v1, k, v)
 			}

--- a/weft/wefttest/wefttest_test.go
+++ b/weft/wefttest/wefttest_test.go
@@ -20,9 +20,6 @@ const (
 //expected csp header for normal responses
 var normalCspHeader = weft.ReturnDefaultCSP()
 
-//expected csp header for error responses
-var errorCspHeader = weft.ReturnDefaultCSP()
-
 // test server and handlers for running the tests
 
 var ts *httptest.Server
@@ -101,7 +98,7 @@ func TestMethodNotAllowed(t *testing.T) {
 	for _, v := range routes {
 		v.Surrogate = maxAge86400
 		v.Content = errContent
-		v.CSP = errorCspHeader //strictCsp for error response
+		v.CSP = normalCspHeader
 
 		i, err := v.MethodNotAllowed(ts.URL, []string{"GET"})
 		if err != nil {
@@ -125,7 +122,7 @@ func TestExtraParameter(t *testing.T) {
 	for _, v := range routes {
 		v.Surrogate = maxAge86400
 		v.Content = errContent
-		v.CSP = errorCspHeader //strictCsp for error response
+		v.CSP = normalCspHeader
 
 		err := v.ExtraParameter(ts.URL, "extra", "parameter")
 		if err != nil {
@@ -152,7 +149,7 @@ func TestFuzzQuery(t *testing.T) {
 	for _, v := range routes {
 		v.Surrogate = maxAge86400
 		v.Content = errContent
-		v.CSP = errorCspHeader //strictCsp for error response
+		v.CSP = normalCspHeader
 		i, err := v.FuzzQuery(ts.URL, wt.FuzzValues)
 		if err != nil {
 			t.Errorf("TestFuzzQuery %s", err.Error())


### PR DESCRIPTION
Reference: https://github.com/GeoNet/tickets/issues/10813

**Changes**
- Remove google analytics url from default CSP script-src directive (not needed as we use nonces)
- Remove unused strict CSP since we're not using it for anything anymore.
- Escape wildcards in CSP when doing regex check in `wefttest`.

## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*