### PR TITLE
Add news link to mobile header

### DIFF
--- a/ui/geonet_header/header.html
+++ b/ui/geonet_header/header.html
@@ -146,6 +146,11 @@
               <a class="dropdown-item" href="{{.Origin}}/data/access/tutorials"> Data Tutorials </a>
             </div>
           </li>
+          <li class="nav-item d-lg-none">
+            <a class="nav-link" href="{{.Origin}}/news" title="News">
+              <span>{{$.NewsIcon}}News</span>
+            </a>
+          </li>
           <li id="mobile-search-item" class="nav-item d-lg-none p-3">
             <form id="search_form_2" class="navbar-form" aria-label="search" role="search" method="POST" action="{{.Origin}}/search">
               <div class="d-flex flex-wrap">


### PR DESCRIPTION
Reference: https://github.com/GeoNet/tickets/issues/12374

Changes proposed in this pull request:

- Add news link to mobile header

## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [x] This is a content (documentation, web page etc) only change.
- [ ] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

From localhost:

<img width="659" alt="image" src="https://user-images.githubusercontent.com/9264582/206318097-bd4b9929-33b1-4e1b-a15f-7fd9a0a3387c.png">

<img width="1038" alt="image" src="https://user-images.githubusercontent.com/9264582/206318157-874b0010-b72b-41d0-985e-b6d9399e0836.png">
(not present on lg-screen upwards)