### PR TITLE
fix overrun on batch slice

### DIFF
--- a/aws/sqs/sqs.go
+++ b/aws/sqs/sqs.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"strings"
 
@@ -228,9 +229,9 @@ func (s *SQS) SendNBatch(ctx context.Context, queueURL string, bodies []string) 
 	var (
 		bodiesLen = len(bodies)
 		maxlen    = 10
-		times     = bodiesLen / maxlen
+		times     = int(math.Ceil(float64(bodiesLen) / float64(maxlen)))
 	)
-	for i := 0; i <= times; i++ {
+	for i := 0; i < times; i++ {
 		batch_end := maxlen * (i + 1)
 		if maxlen*(i+1) > bodiesLen {
 			batch_end = bodiesLen

--- a/aws/sqs/sqs.go
+++ b/aws/sqs/sqs.go
@@ -231,7 +231,11 @@ func (s *SQS) SendNBatch(ctx context.Context, queueURL string, bodies []string) 
 		times     = bodiesLen / maxlen
 	)
 	for i := 0; i <= times; i++ {
-		var bodies_batch = bodies[maxlen*i : maxlen*(i+1)]
+		batch_end := maxlen * (i + 1)
+		if maxlen*(i+1) > bodiesLen {
+			batch_end = bodiesLen
+		}
+		var bodies_batch = bodies[maxlen*i : batch_end]
 		err := s.SendBatch(ctx, queueURL, bodies_batch)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Proposed Changes

I've put in a bad slice syntax in the batch request change and found out at runtime testing with docker-gamit.

```
panic: runtime error: slice bounds out of range [:20] with capacity 16

goroutine 1 [running]:
github.com/GeoNet/kit/aws/sqs.(*SQS).SendNBatch(0xc0000c5e80?, {0x85dc50, 0xc000028110}, {0x7d8328, 0x50}, {0xc0001e4000, 0x2d?, 0x10})
        /home/mossc/workspace/docker-gamit/cmd/vendor/github.com/GeoNet/kit/aws/sqs/sqs.go:234 +0x130
main.main()
        /home/mossc/workspace/docker-gamit/cmd/gamit-cli-internal/main.go:106 +0x785
```

Changes proposed in this pull request:

- fix slice syntax to stay within bounds

## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*