### PR TITLE
add ability to use custom AWS endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,28 @@ language: go
 go:
 - 1.16.13
 
-# dependencies for kit are not vendored and should always build with the latest version.
+services:
+  - docker
+
 install:
+  # dependencies for kit are not vendored and should always build with the latest version.
   - go get github.com/golang/protobuf/proto
   - go get google.golang.org/protobuf/proto
   - go get github.com/golang/groupcache
+  - docker pull localstack/localstack
+  - export PATH=$PATH:$HOME/.local/bin
 
 before_script:
  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin
+ - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+ - sudo unzip -o awscliv2.zip
+ - sudo ./aws/install
+ - docker run -d --rm -it -p 4566:4566 -p 4510-4559:4510-4559 localstack/localstack
 
 script:
   - test -z "$(gofmt -s -l `find . -name "*.go" | egrep -v vendor` | tee /dev/stderr)"
   - go vet ./...
-  - go test -v ./...
+  - go test -v ./... --tags localstack
   - golangci-lint run -E gosec # default linters + gosec
 
 notifications:

--- a/aws/s3/s3.go
+++ b/aws/s3/s3.go
@@ -78,7 +78,26 @@ func getConfig() (aws.Config, error) {
 	if os.Getenv("AWS_REGION") == "" {
 		return aws.Config{}, errors.New("AWS_REGION is not set")
 	}
-	cfg, err := config.LoadDefaultConfig(context.TODO())
+
+	var cfg aws.Config
+	var err error
+
+	if awsEndpoint := os.Getenv("CUSTOM_AWS_ENDPOINT_URL"); awsEndpoint != "" {
+		customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+			return aws.Endpoint{
+				PartitionID:       "aws",
+				URL:               awsEndpoint,
+				HostnameImmutable: true,
+			}, nil
+		})
+
+		cfg, err = config.LoadDefaultConfig(
+			context.TODO(),
+			config.WithEndpointResolverWithOptions(customResolver))
+	} else {
+		cfg, err = config.LoadDefaultConfig(context.TODO())
+	}
+
 	if err != nil {
 		return aws.Config{}, err
 	}

--- a/aws/s3/s3_integration_test.go
+++ b/aws/s3/s3_integration_test.go
@@ -1,0 +1,541 @@
+//go:build localstack
+// +build localstack
+
+package s3
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	CustomAWSEndpointURL = "http://localhost:4566"
+	AWSRegion            = "ap-southeast-2"
+	TestBucket           = "test-bucket"
+
+	TestObjectKey  = "test-key"
+	TestObjectData = "some data"
+
+	TestMetaKey   = "test-meta-key"
+	TestMetaValue = "test-meta-value"
+
+	TestPrefix          = "test-prefix"
+	TestPrefixDelimiter = "_"
+
+	TestNewKey = "test-new-key"
+)
+
+// helper functions
+
+func setup() {
+	// setup environment variables to access LocalStack
+	os.Setenv("AWS_REGION", AWSRegion)
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+	os.Setenv("AWS_ACCESS_KEY_ID", "test")
+	os.Setenv("CUSTOM_AWS_ENDPOINT_URL", CustomAWSEndpointURL)
+
+	// create bucket
+	if err := exec.Command(
+		"aws", "s3api",
+		"create-bucket",
+		"--bucket", TestBucket,
+		"--create-bucket-configuration", fmt.Sprintf(
+			"{\"LocationConstraint\": \"%v\"}", AWSRegion),
+		"--endpoint-url", CustomAWSEndpointURL).Run(); err != nil {
+
+		panic(err)
+	}
+}
+
+func teardown() {
+	if err := exec.Command(
+		"aws", "s3",
+		"rb", fmt.Sprintf("s3://%v", TestBucket),
+		"--force",
+		"--endpoint-url", CustomAWSEndpointURL).Run(); err != nil {
+
+		panic(err)
+	}
+}
+
+func awsCmdPopulateBucket() {
+	// create test data
+	tmpDir, _ := os.MkdirTemp("", "")
+	defer os.RemoveAll(tmpDir)
+
+	testDataFilepath := filepath.Join(tmpDir, "data.txt")
+	testFile, _ := os.Create(testDataFilepath)
+	testFile.WriteString(TestObjectData)
+	testFile.Close()
+
+	// populate bucket
+	if err := exec.Command(
+		"aws", "s3api",
+		"put-object",
+		"--bucket", TestBucket,
+		"--key", TestObjectKey,
+		"--body", testDataFilepath,
+		"--metadata", fmt.Sprintf("%v=%v", TestMetaKey, TestMetaValue),
+		"--endpoint-url", CustomAWSEndpointURL).Run(); err != nil {
+
+		panic(err)
+	}
+}
+
+func awsCmdExists(key string) bool {
+	if err := exec.Command(
+		"aws", "s3api",
+		"head-object",
+		"--bucket", TestBucket,
+		"--key", key,
+		"--endpoint-url", CustomAWSEndpointURL).Run(); err != nil {
+
+		return false
+	}
+	return true
+}
+
+func awsCmdPutKey(key string) {
+	if err := exec.Command(
+		"aws", "s3api",
+		"put-object",
+		"--bucket", TestBucket,
+		"--key", key,
+		"--endpoint-url", CustomAWSEndpointURL).Run(); err != nil {
+
+		panic(err)
+	}
+}
+
+type awsMeta struct {
+	lastModified  time.Time
+	contentLength int64
+	meta          map[string]string
+}
+
+func awsCmdMeta() awsMeta {
+	var rvalue = awsMeta{
+		meta: make(map[string]string),
+	}
+
+	cmd := exec.Command(
+		"aws", "s3api",
+		"head-object",
+		"--bucket", TestBucket,
+		"--key", TestObjectKey,
+		"--endpoint-url", CustomAWSEndpointURL)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		panic(err)
+	}
+
+	var metaData map[string]interface{}
+	json.Unmarshal(out, &metaData)
+	testLastModified, err := time.Parse(
+		"2006-01-02T15:04:05", metaData["LastModified"].(string)[0:19])
+	if err != nil {
+		panic(err)
+	}
+
+	rvalue.lastModified = testLastModified
+	rvalue.contentLength = int64(metaData["ContentLength"].(float64))
+	// note: assumes string=string type aws meta data
+	for k, v := range metaData["Metadata"].(map[string]interface{}) {
+		rvalue.meta[k] = v.(string)
+	}
+
+	return rvalue
+}
+
+func awsCmdGetTestObject() string {
+	tmpDir, _ := os.MkdirTemp("", "")
+	defer os.RemoveAll(tmpDir)
+
+	testDataFilepath := filepath.Join(tmpDir, "data.txt")
+
+	if err := exec.Command(
+		"aws", "s3api",
+		"get-object",
+		"--bucket", TestBucket,
+		"--key", TestObjectKey,
+		"--endpoint-url", CustomAWSEndpointURL,
+		testDataFilepath).Run(); err != nil {
+		panic(err)
+	}
+
+	testFileContents, _ := os.ReadFile(testDataFilepath)
+	return string(testFileContents)
+}
+
+// THE TESTS
+
+func TestCreateS3ClientAndReady(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	// test good case
+
+	// ACTION
+	client, err := New()
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.True(t, client.Ready())
+
+	// test bad case
+
+	// ARRANGE
+	os.Unsetenv("AWS_REGION")
+
+	// ACTION
+	client, err = New()
+
+	// ASSERT
+	assert.NotNil(t, err)
+	assert.False(t, client.Ready())
+}
+
+func TestCreateS3ClientWithMaxRetries(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	// ACTION
+	_, err := NewWithMaxRetries(2)
+
+	// ASSERT
+	assert.Nil(t, err)
+
+	// test bad case
+
+	// ARRANGE
+	os.Unsetenv("AWS_REGION")
+
+	// ACTION
+	_, err = NewWithMaxRetries(2)
+
+	// ASSERT
+	assert.NotNil(t, err)
+}
+func TestS3Get(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	awsCmdPopulateBucket()
+
+	client, err := New()
+	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
+
+	// ACTION
+	dataObject := bytes.Buffer{}
+	err = client.Get(TestBucket, TestObjectKey, "", &dataObject)
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.Equal(t, TestObjectData, dataObject.String())
+}
+
+func TestS3GetWithLastModified(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	awsCmdPopulateBucket()
+
+	client, err := New()
+	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
+
+	meta := awsCmdMeta()
+
+	// ACTION
+	dataObject := bytes.Buffer{}
+	lastModified, err := client.GetWithLastModified(
+		TestBucket, TestObjectKey, "", &dataObject)
+
+	// ASSERT
+	assert.Nil(t, err)
+
+	// object is what we expect
+	assert.Equal(t, TestObjectData, dataObject.String())
+
+	// modified time is what we expect
+	assert.Equal(t, meta.lastModified, lastModified)
+
+	// bonus test, LastModified function
+	lastModified, err = client.LastModified(TestBucket, TestObjectKey, "")
+	assert.Nil(t, err)
+	assert.Equal(t, meta.lastModified, lastModified)
+}
+
+func TestS3GetMeta(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	awsCmdPopulateBucket()
+
+	client, err := New()
+	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
+
+	// ACTION
+	meta, err := client.GetMeta(TestBucket, TestObjectKey, "")
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.Equal(t, TestMetaValue, meta[TestMetaKey])
+}
+
+func TestS3GetContentSizeTime(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	awsCmdPopulateBucket()
+
+	meta := awsCmdMeta()
+
+	client, err := New()
+	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
+
+	// ACTION
+	contentLength, lastModified, err := client.GetContentSizeTime(TestBucket, TestObjectKey)
+
+	// ASSERT
+	assert.Equal(t, meta.contentLength, contentLength)
+	assert.Equal(t, meta.lastModified, lastModified)
+}
+
+func TestS3Put(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	client, err := New()
+	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
+
+	// ACTION
+	err = client.Put(TestBucket, TestObjectKey, []byte(TestObjectData))
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.Equal(t, TestObjectData, awsCmdGetTestObject())
+}
+
+func TestS3PutWithMetadata(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	client, err := New()
+	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
+
+	// ACTION
+	err = client.PutWithMetadata(
+		TestBucket,
+		TestObjectKey,
+		[]byte(TestObjectData),
+		map[string]string{TestMetaKey: TestMetaValue})
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.Equal(t, TestObjectData, awsCmdGetTestObject())
+
+	// test meta data
+	metaData := awsCmdMeta()
+	assert.Equal(t, TestMetaValue, metaData.meta[TestMetaKey])
+}
+
+func TestS3Exists(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	awsCmdPopulateBucket()
+
+	client, err := New()
+	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
+
+	// ACTION
+	exists, err := client.Exists(TestBucket, TestObjectKey)
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.True(t, exists)
+
+	// ACTION
+	exists, err = client.Exists(TestBucket, "thisdoesntexists")
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.False(t, exists)
+}
+
+func TestS3List(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	// create several test inputs
+	var tests = []struct {
+		prefix     string
+		numObjects int
+	}{
+		{"prefix1", 2},
+		{"prefix2", 3},
+	}
+
+	//populate bucket with several objects, some with common prefix
+	for _, tt := range tests {
+		for i := 0; i < tt.numObjects; i++ {
+			awsCmdPutKey(fmt.Sprintf("%v-%v", tt.prefix, i))
+		}
+	}
+
+	client, err := New()
+	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
+
+	for _, tt := range tests {
+		// ACTION
+		listing, err := client.List(TestBucket, tt.prefix, 1000)
+
+		// ASSERT
+
+		// got listing ok
+		assert.Nil(t, err)
+
+		// expected number of objects in list
+		assert.Equal(t, tt.numObjects, len(listing))
+
+		// expected prefix
+		for _, item := range listing {
+			assert.True(t, strings.HasPrefix(item, tt.prefix))
+		}
+
+		// sneak in a ListAll test as well
+		listAll, err := client.ListAll(TestBucket, tt.prefix)
+		assert.Nil(t, err)
+		assert.Equal(t, listing, listAll)
+	}
+}
+
+func TestS3PrefixExists(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	awsCmdPutKey(TestPrefix + "/" + TestObjectKey)
+
+	client, err := New()
+	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
+
+	// ACTION
+	exists, err := client.PrefixExists(TestBucket, TestPrefix)
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.Equal(t, true, exists)
+
+	// ACTION
+	exists, err = client.PrefixExists(TestBucket, "thisdoesnotexists")
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.Equal(t, false, exists)
+}
+
+func TestS3ListCommonPrefixes(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	// create several test inputs
+	var testKeys = []string{
+		// prefix_1 etc.
+		TestPrefix + TestPrefixDelimiter + "file1",
+		TestPrefix + TestPrefixDelimiter + "file2",
+		TestPrefix + TestPrefixDelimiter + "file3",
+		TestPrefix + TestPrefixDelimiter + "file4",
+	}
+
+	//populate bucket with several objects, some with common prefix
+	for _, key := range testKeys {
+		awsCmdPutKey(key)
+	}
+
+	client, err := New()
+	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
+
+	// ACTION
+	listing, err := client.ListCommonPrefixes(TestBucket, TestPrefix, "_")
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.Equal(t, []string{TestPrefix + TestPrefixDelimiter}, listing)
+
+	// test ListObjects
+
+	// ACTION
+	objects, err := client.ListObjects(TestBucket, TestPrefix)
+	var keys []string
+	for _, object := range objects {
+		keys = append(keys, *object.Key)
+	}
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.Equal(t, testKeys, keys)
+}
+
+func TestS3Delete(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	awsCmdPopulateBucket()
+	require.True(t, awsCmdExists(TestObjectKey))
+
+	client, err := New()
+	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
+
+	// ACTION
+	err = client.Delete(TestBucket, TestObjectKey)
+
+	// ASSERT
+	assert.Nil(t, err)
+
+	// should no longer exists
+	assert.False(t, awsCmdExists(TestObjectKey))
+}
+
+func TestS3Copy(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	awsCmdPopulateBucket()
+
+	client, err := New()
+	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
+
+	// ACTION
+	err = client.Copy(TestBucket, TestNewKey, TestBucket+"/"+TestObjectKey)
+
+	// ASSERT
+	assert.Nil(t, err)
+
+	// new object exists
+	assert.True(t, awsCmdExists(TestNewKey))
+}

--- a/aws/s3/s3_integration_test.go
+++ b/aws/s3/s3_integration_test.go
@@ -19,39 +19,39 @@ import (
 )
 
 const (
-	CustomAWSEndpointURL = "http://localhost:4566"
-	AWSRegion            = "ap-southeast-2"
-	TestBucket           = "test-bucket"
+	customAWSEndpoint = "http://localhost:4566"
+	awsRegion         = "ap-southeast-2"
+	testBucket        = "test-bucket"
 
-	TestObjectKey  = "test-key"
-	TestObjectData = "some data"
+	testObjectKey  = "test-key"
+	testObjectData = "some data"
 
-	TestMetaKey   = "test-meta-key"
-	TestMetaValue = "test-meta-value"
+	testMetaKey   = "test-meta-key"
+	testMetaValue = "test-meta-value"
 
-	TestPrefix          = "test-prefix"
-	TestPrefixDelimiter = "_"
+	testPrefix          = "test-prefix"
+	testPrefixDelimiter = "_"
 
-	TestNewKey = "test-new-key"
+	testNewKey = "test-new-key"
 )
 
 // helper functions
 
 func setup() {
 	// setup environment variables to access LocalStack
-	os.Setenv("AWS_REGION", AWSRegion)
+	os.Setenv("AWS_REGION", awsRegion)
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "test")
 	os.Setenv("AWS_ACCESS_KEY_ID", "test")
-	os.Setenv("CUSTOM_AWS_ENDPOINT_URL", CustomAWSEndpointURL)
+	os.Setenv("CUSTOM_AWS_ENDPOINT_URL", customAWSEndpoint)
 
 	// create bucket
 	if err := exec.Command(
 		"aws", "s3api",
 		"create-bucket",
-		"--bucket", TestBucket,
+		"--bucket", testBucket,
 		"--create-bucket-configuration", fmt.Sprintf(
-			"{\"LocationConstraint\": \"%v\"}", AWSRegion),
-		"--endpoint-url", CustomAWSEndpointURL).Run(); err != nil {
+			"{\"LocationConstraint\": \"%v\"}", awsRegion),
+		"--endpoint-url", customAWSEndpoint).Run(); err != nil {
 
 		panic(err)
 	}
@@ -60,9 +60,9 @@ func setup() {
 func teardown() {
 	if err := exec.Command(
 		"aws", "s3",
-		"rb", fmt.Sprintf("s3://%v", TestBucket),
+		"rb", fmt.Sprintf("s3://%v", testBucket),
 		"--force",
-		"--endpoint-url", CustomAWSEndpointURL).Run(); err != nil {
+		"--endpoint-url", customAWSEndpoint).Run(); err != nil {
 
 		panic(err)
 	}
@@ -75,18 +75,18 @@ func awsCmdPopulateBucket() {
 
 	testDataFilepath := filepath.Join(tmpDir, "data.txt")
 	testFile, _ := os.Create(testDataFilepath)
-	testFile.WriteString(TestObjectData)
+	testFile.WriteString(testObjectData)
 	testFile.Close()
 
 	// populate bucket
 	if err := exec.Command(
 		"aws", "s3api",
 		"put-object",
-		"--bucket", TestBucket,
-		"--key", TestObjectKey,
+		"--bucket", testBucket,
+		"--key", testObjectKey,
 		"--body", testDataFilepath,
-		"--metadata", fmt.Sprintf("%v=%v", TestMetaKey, TestMetaValue),
-		"--endpoint-url", CustomAWSEndpointURL).Run(); err != nil {
+		"--metadata", fmt.Sprintf("%v=%v", testMetaKey, testMetaValue),
+		"--endpoint-url", customAWSEndpoint).Run(); err != nil {
 
 		panic(err)
 	}
@@ -96,9 +96,9 @@ func awsCmdExists(key string) bool {
 	if err := exec.Command(
 		"aws", "s3api",
 		"head-object",
-		"--bucket", TestBucket,
+		"--bucket", testBucket,
 		"--key", key,
-		"--endpoint-url", CustomAWSEndpointURL).Run(); err != nil {
+		"--endpoint-url", customAWSEndpoint).Run(); err != nil {
 
 		return false
 	}
@@ -109,9 +109,9 @@ func awsCmdPutKey(key string) {
 	if err := exec.Command(
 		"aws", "s3api",
 		"put-object",
-		"--bucket", TestBucket,
+		"--bucket", testBucket,
 		"--key", key,
-		"--endpoint-url", CustomAWSEndpointURL).Run(); err != nil {
+		"--endpoint-url", customAWSEndpoint).Run(); err != nil {
 
 		panic(err)
 	}
@@ -131,9 +131,9 @@ func awsCmdMeta() awsMeta {
 	cmd := exec.Command(
 		"aws", "s3api",
 		"head-object",
-		"--bucket", TestBucket,
-		"--key", TestObjectKey,
-		"--endpoint-url", CustomAWSEndpointURL)
+		"--bucket", testBucket,
+		"--key", testObjectKey,
+		"--endpoint-url", customAWSEndpoint)
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -167,9 +167,9 @@ func awsCmdGetTestObject() string {
 	if err := exec.Command(
 		"aws", "s3api",
 		"get-object",
-		"--bucket", TestBucket,
-		"--key", TestObjectKey,
-		"--endpoint-url", CustomAWSEndpointURL,
+		"--bucket", testBucket,
+		"--key", testObjectKey,
+		"--endpoint-url", customAWSEndpoint,
 		testDataFilepath).Run(); err != nil {
 		panic(err)
 	}
@@ -241,11 +241,11 @@ func TestS3Get(t *testing.T) {
 
 	// ACTION
 	dataObject := bytes.Buffer{}
-	err = client.Get(TestBucket, TestObjectKey, "", &dataObject)
+	err = client.Get(testBucket, testObjectKey, "", &dataObject)
 
 	// ASSERT
 	assert.Nil(t, err)
-	assert.Equal(t, TestObjectData, dataObject.String())
+	assert.Equal(t, testObjectData, dataObject.String())
 }
 
 func TestS3GetWithLastModified(t *testing.T) {
@@ -263,19 +263,19 @@ func TestS3GetWithLastModified(t *testing.T) {
 	// ACTION
 	dataObject := bytes.Buffer{}
 	lastModified, err := client.GetWithLastModified(
-		TestBucket, TestObjectKey, "", &dataObject)
+		testBucket, testObjectKey, "", &dataObject)
 
 	// ASSERT
 	assert.Nil(t, err)
 
 	// object is what we expect
-	assert.Equal(t, TestObjectData, dataObject.String())
+	assert.Equal(t, testObjectData, dataObject.String())
 
 	// modified time is what we expect
 	assert.Equal(t, meta.lastModified, lastModified)
 
 	// bonus test, LastModified function
-	lastModified, err = client.LastModified(TestBucket, TestObjectKey, "")
+	lastModified, err = client.LastModified(testBucket, testObjectKey, "")
 	assert.Nil(t, err)
 	assert.Equal(t, meta.lastModified, lastModified)
 }
@@ -291,11 +291,11 @@ func TestS3GetMeta(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
 
 	// ACTION
-	meta, err := client.GetMeta(TestBucket, TestObjectKey, "")
+	meta, err := client.GetMeta(testBucket, testObjectKey, "")
 
 	// ASSERT
 	assert.Nil(t, err)
-	assert.Equal(t, TestMetaValue, meta[TestMetaKey])
+	assert.Equal(t, testMetaValue, meta[testMetaKey])
 }
 
 func TestS3GetContentSizeTime(t *testing.T) {
@@ -311,7 +311,7 @@ func TestS3GetContentSizeTime(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
 
 	// ACTION
-	contentLength, lastModified, err := client.GetContentSizeTime(TestBucket, TestObjectKey)
+	contentLength, lastModified, err := client.GetContentSizeTime(testBucket, testObjectKey)
 
 	// ASSERT
 	assert.Equal(t, meta.contentLength, contentLength)
@@ -327,11 +327,11 @@ func TestS3Put(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
 
 	// ACTION
-	err = client.Put(TestBucket, TestObjectKey, []byte(TestObjectData))
+	err = client.Put(testBucket, testObjectKey, []byte(testObjectData))
 
 	// ASSERT
 	assert.Nil(t, err)
-	assert.Equal(t, TestObjectData, awsCmdGetTestObject())
+	assert.Equal(t, testObjectData, awsCmdGetTestObject())
 }
 
 func TestS3PutWithMetadata(t *testing.T) {
@@ -344,18 +344,18 @@ func TestS3PutWithMetadata(t *testing.T) {
 
 	// ACTION
 	err = client.PutWithMetadata(
-		TestBucket,
-		TestObjectKey,
-		[]byte(TestObjectData),
-		map[string]string{TestMetaKey: TestMetaValue})
+		testBucket,
+		testObjectKey,
+		[]byte(testObjectData),
+		map[string]string{testMetaKey: testMetaValue})
 
 	// ASSERT
 	assert.Nil(t, err)
-	assert.Equal(t, TestObjectData, awsCmdGetTestObject())
+	assert.Equal(t, testObjectData, awsCmdGetTestObject())
 
 	// test meta data
 	metaData := awsCmdMeta()
-	assert.Equal(t, TestMetaValue, metaData.meta[TestMetaKey])
+	assert.Equal(t, testMetaValue, metaData.meta[testMetaKey])
 }
 
 func TestS3Exists(t *testing.T) {
@@ -369,14 +369,14 @@ func TestS3Exists(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
 
 	// ACTION
-	exists, err := client.Exists(TestBucket, TestObjectKey)
+	exists, err := client.Exists(testBucket, testObjectKey)
 
 	// ASSERT
 	assert.Nil(t, err)
 	assert.True(t, exists)
 
 	// ACTION
-	exists, err = client.Exists(TestBucket, "thisdoesntexists")
+	exists, err = client.Exists(testBucket, "thisdoesntexists")
 
 	// ASSERT
 	assert.Nil(t, err)
@@ -409,7 +409,7 @@ func TestS3List(t *testing.T) {
 
 	for _, tt := range tests {
 		// ACTION
-		listing, err := client.List(TestBucket, tt.prefix, 1000)
+		listing, err := client.List(testBucket, tt.prefix, 1000)
 
 		// ASSERT
 
@@ -425,7 +425,7 @@ func TestS3List(t *testing.T) {
 		}
 
 		// sneak in a ListAll test as well
-		listAll, err := client.ListAll(TestBucket, tt.prefix)
+		listAll, err := client.ListAll(testBucket, tt.prefix)
 		assert.Nil(t, err)
 		assert.Equal(t, listing, listAll)
 	}
@@ -436,20 +436,20 @@ func TestS3PrefixExists(t *testing.T) {
 	setup()
 	defer teardown()
 
-	awsCmdPutKey(TestPrefix + "/" + TestObjectKey)
+	awsCmdPutKey(testPrefix + "/" + testObjectKey)
 
 	client, err := New()
 	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
 
 	// ACTION
-	exists, err := client.PrefixExists(TestBucket, TestPrefix)
+	exists, err := client.PrefixExists(testBucket, testPrefix)
 
 	// ASSERT
 	assert.Nil(t, err)
 	assert.Equal(t, true, exists)
 
 	// ACTION
-	exists, err = client.PrefixExists(TestBucket, "thisdoesnotexists")
+	exists, err = client.PrefixExists(testBucket, "thisdoesnotexists")
 
 	// ASSERT
 	assert.Nil(t, err)
@@ -464,10 +464,10 @@ func TestS3ListCommonPrefixes(t *testing.T) {
 	// create several test inputs
 	var testKeys = []string{
 		// prefix_1 etc.
-		TestPrefix + TestPrefixDelimiter + "file1",
-		TestPrefix + TestPrefixDelimiter + "file2",
-		TestPrefix + TestPrefixDelimiter + "file3",
-		TestPrefix + TestPrefixDelimiter + "file4",
+		testPrefix + testPrefixDelimiter + "file1",
+		testPrefix + testPrefixDelimiter + "file2",
+		testPrefix + testPrefixDelimiter + "file3",
+		testPrefix + testPrefixDelimiter + "file4",
 	}
 
 	//populate bucket with several objects, some with common prefix
@@ -479,16 +479,16 @@ func TestS3ListCommonPrefixes(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
 
 	// ACTION
-	listing, err := client.ListCommonPrefixes(TestBucket, TestPrefix, "_")
+	listing, err := client.ListCommonPrefixes(testBucket, testPrefix, "_")
 
 	// ASSERT
 	assert.Nil(t, err)
-	assert.Equal(t, []string{TestPrefix + TestPrefixDelimiter}, listing)
+	assert.Equal(t, []string{testPrefix + testPrefixDelimiter}, listing)
 
 	// test ListObjects
 
 	// ACTION
-	objects, err := client.ListObjects(TestBucket, TestPrefix)
+	objects, err := client.ListObjects(testBucket, testPrefix)
 	var keys []string
 	for _, object := range objects {
 		keys = append(keys, *object.Key)
@@ -505,19 +505,19 @@ func TestS3Delete(t *testing.T) {
 	defer teardown()
 
 	awsCmdPopulateBucket()
-	require.True(t, awsCmdExists(TestObjectKey))
+	require.True(t, awsCmdExists(testObjectKey))
 
 	client, err := New()
 	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
 
 	// ACTION
-	err = client.Delete(TestBucket, TestObjectKey)
+	err = client.Delete(testBucket, testObjectKey)
 
 	// ASSERT
 	assert.Nil(t, err)
 
 	// should no longer exists
-	assert.False(t, awsCmdExists(TestObjectKey))
+	assert.False(t, awsCmdExists(testObjectKey))
 }
 
 func TestS3Copy(t *testing.T) {
@@ -531,11 +531,11 @@ func TestS3Copy(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("Error creating s3 client: %v", err))
 
 	// ACTION
-	err = client.Copy(TestBucket, TestNewKey, TestBucket+"/"+TestObjectKey)
+	err = client.Copy(testBucket, testNewKey, testBucket+"/"+testObjectKey)
 
 	// ASSERT
 	assert.Nil(t, err)
 
 	// new object exists
-	assert.True(t, awsCmdExists(TestNewKey))
+	assert.True(t, awsCmdExists(testNewKey))
 }

--- a/aws/sns/sns.go
+++ b/aws/sns/sns.go
@@ -46,7 +46,25 @@ func getConfig() (aws.Config, error) {
 	if os.Getenv("AWS_REGION") == "" {
 		return aws.Config{}, errors.New("AWS_REGION is not set")
 	}
-	cfg, err := config.LoadDefaultConfig(context.TODO())
+
+	var cfg aws.Config
+	var err error
+
+	if awsEndpoint := os.Getenv("CUSTOM_AWS_ENDPOINT_URL"); awsEndpoint != "" {
+		customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+			return aws.Endpoint{
+				PartitionID: "aws",
+				URL:         awsEndpoint,
+			}, nil
+		})
+
+		cfg, err = config.LoadDefaultConfig(
+			context.TODO(),
+			config.WithEndpointResolverWithOptions(customResolver))
+	} else {
+		cfg, err = config.LoadDefaultConfig(context.TODO())
+	}
+
 	if err != nil {
 		return aws.Config{}, err
 	}

--- a/aws/sqs/sqs.go
+++ b/aws/sqs/sqs.go
@@ -58,7 +58,26 @@ func getConfig() (aws.Config, error) {
 	if os.Getenv("AWS_REGION") == "" {
 		return aws.Config{}, errors.New("AWS_REGION is not set")
 	}
-	cfg, err := config.LoadDefaultConfig(context.TODO())
+
+	var cfg aws.Config
+	var err error
+
+	if awsEndpoint := os.Getenv("CUSTOM_AWS_ENDPOINT_URL"); awsEndpoint != "" {
+		customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+			return aws.Endpoint{
+				PartitionID:   "aws",
+				SigningRegion: region,
+				URL:           awsEndpoint,
+			}, nil
+		})
+
+		cfg, err = config.LoadDefaultConfig(
+			context.TODO(),
+			config.WithEndpointResolverWithOptions(customResolver))
+	} else {
+		cfg, err = config.LoadDefaultConfig(context.TODO())
+	}
+
 	if err != nil {
 		return aws.Config{}, err
 	}

--- a/aws/sqs/sqs_integration_test.go
+++ b/aws/sqs/sqs_integration_test.go
@@ -18,28 +18,28 @@ import (
 )
 
 const (
-	CustomAWSEndpointURL = "http://localhost:4566"
-	AWSRegion            = "ap-southeast-2"
-	TestQueue            = "test-queue"
-	TestMessage          = "test message"
+	cutomAWSEndpointURL = "http://localhost:4566"
+	awsRegion           = "ap-southeast-2"
+	testQueue           = "test-queue"
+	testMessage         = "test message"
 )
 
 // helper functions
 
 func setup() {
 	// setup environment variables to access LocalStack
-	os.Setenv("AWS_REGION", AWSRegion)
+	os.Setenv("AWS_REGION", awsRegion)
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "test")
 	os.Setenv("AWS_ACCESS_KEY_ID", "test")
-	os.Setenv("CUSTOM_AWS_ENDPOINT_URL", CustomAWSEndpointURL)
+	os.Setenv("CUSTOM_AWS_ENDPOINT_URL", cutomAWSEndpointURL)
 
 	// create queue
 	if err := exec.Command(
 		"aws", "sqs",
 		"create-queue",
-		"--queue-name", TestQueue,
-		"--endpoint-url", CustomAWSEndpointURL,
-		"--region", AWSRegion).Run(); err != nil {
+		"--queue-name", testQueue,
+		"--endpoint-url", cutomAWSEndpointURL,
+		"--region", awsRegion).Run(); err != nil {
 
 		panic(err)
 	}
@@ -50,8 +50,8 @@ func teardown() {
 		"aws", "sqs",
 		"delete-queue",
 		"--queue-url", awsCmdQueueURL(),
-		"--region", AWSRegion,
-		"--endpoint-url", CustomAWSEndpointURL).Run(); err != nil {
+		"--region", awsRegion,
+		"--endpoint-url", cutomAWSEndpointURL).Run(); err != nil {
 
 		panic(err)
 	}
@@ -61,9 +61,9 @@ func awsCmdQueueURL() string {
 	if out, err := exec.Command(
 		"aws", "sqs",
 		"get-queue-url",
-		"--queue-name", TestQueue,
-		"--region", AWSRegion,
-		"--endpoint-url", CustomAWSEndpointURL).CombinedOutput(); err != nil {
+		"--queue-name", testQueue,
+		"--region", awsRegion,
+		"--endpoint-url", cutomAWSEndpointURL).CombinedOutput(); err != nil {
 
 		panic(err)
 	} else {
@@ -78,9 +78,9 @@ func awsCmdSendMessage() {
 		"aws", "sqs",
 		"send-message",
 		"--queue-url", awsCmdQueueURL(),
-		"--message-body", TestMessage,
-		"--region", AWSRegion,
-		"--endpoint-url", CustomAWSEndpointURL).Run(); err != nil {
+		"--message-body", testMessage,
+		"--region", awsRegion,
+		"--endpoint-url", cutomAWSEndpointURL).Run(); err != nil {
 
 		panic(err)
 	}
@@ -92,8 +92,8 @@ func awsCmdReceiveMessage() string {
 		"receive-message",
 		"--queue-url", awsCmdQueueURL(),
 		"--attribute-names", "body",
-		"--region", AWSRegion,
-		"--endpoint-url", CustomAWSEndpointURL).CombinedOutput(); err != nil {
+		"--region", awsRegion,
+		"--endpoint-url", cutomAWSEndpointURL).CombinedOutput(); err != nil {
 
 		panic(err)
 	} else {
@@ -109,8 +109,8 @@ func awsCmdQueueCount() int {
 		"get-queue-attributes",
 		"--queue-url", awsCmdQueueURL(),
 		"--attribute-name", "ApproximateNumberOfMessages",
-		"--region", AWSRegion,
-		"--endpoint-url", CustomAWSEndpointURL).CombinedOutput(); err != nil {
+		"--region", awsRegion,
+		"--endpoint-url", cutomAWSEndpointURL).CombinedOutput(); err != nil {
 
 		panic(err)
 	} else {
@@ -187,7 +187,7 @@ func TestSQSReceive(t *testing.T) {
 
 	// ASSERT
 	assert.Nil(t, err)
-	assert.Equal(t, TestMessage, receivedMessage.Body)
+	assert.Equal(t, testMessage, receivedMessage.Body)
 }
 
 func TestSQSReceiveWithAttributes(t *testing.T) {
@@ -240,11 +240,11 @@ func TestSQSSend(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("Error creating sqs client: %v", err))
 
 	// ACTION
-	err = client.Send(awsCmdQueueURL(), TestMessage)
+	err = client.Send(awsCmdQueueURL(), testMessage)
 
 	// ASSERT
 	assert.Nil(t, err)
-	assert.Equal(t, TestMessage, awsCmdReceiveMessage())
+	assert.Equal(t, testMessage, awsCmdReceiveMessage())
 }
 
 func TestSQSSendWithDelay(t *testing.T) {
@@ -256,7 +256,7 @@ func TestSQSSendWithDelay(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("Error creating sqs client: %v", err))
 
 	// ACTION
-	err = client.SendWithDelay(awsCmdQueueURL(), TestMessage, 4) // delay seconds
+	err = client.SendWithDelay(awsCmdQueueURL(), testMessage, 4) // delay seconds
 	time.Sleep(2 * time.Second)
 	messageCountBeforeDelay := awsCmdQueueCount()
 	time.Sleep(3 * time.Second)
@@ -277,7 +277,7 @@ func TestGetQueueUrl(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("Error creating sqs client: %v", err))
 
 	// ACTION
-	queueURL, err := client.GetQueueUrl(TestQueue)
+	queueURL, err := client.GetQueueUrl(testQueue)
 
 	// ASSERT
 	assert.Nil(t, err)

--- a/aws/sqs/sqs_integration_test.go
+++ b/aws/sqs/sqs_integration_test.go
@@ -1,0 +1,285 @@
+//go:build localstack
+// +build localstack
+
+package sqs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	CustomAWSEndpointURL = "http://localhost:4566"
+	AWSRegion            = "ap-southeast-2"
+	TestQueue            = "test-queue"
+	TestMessage          = "test message"
+)
+
+// helper functions
+
+func setup() {
+	// setup environment variables to access LocalStack
+	os.Setenv("AWS_REGION", AWSRegion)
+	os.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+	os.Setenv("AWS_ACCESS_KEY_ID", "test")
+	os.Setenv("CUSTOM_AWS_ENDPOINT_URL", CustomAWSEndpointURL)
+
+	// create queue
+	if err := exec.Command(
+		"aws", "sqs",
+		"create-queue",
+		"--queue-name", TestQueue,
+		"--endpoint-url", CustomAWSEndpointURL,
+		"--region", AWSRegion).Run(); err != nil {
+
+		panic(err)
+	}
+}
+
+func teardown() {
+	if err := exec.Command(
+		"aws", "sqs",
+		"delete-queue",
+		"--queue-url", awsCmdQueueURL(),
+		"--region", AWSRegion,
+		"--endpoint-url", CustomAWSEndpointURL).Run(); err != nil {
+
+		panic(err)
+	}
+}
+
+func awsCmdQueueURL() string {
+	if out, err := exec.Command(
+		"aws", "sqs",
+		"get-queue-url",
+		"--queue-name", TestQueue,
+		"--region", AWSRegion,
+		"--endpoint-url", CustomAWSEndpointURL).CombinedOutput(); err != nil {
+
+		panic(err)
+	} else {
+		var payload map[string]string
+		json.Unmarshal(out, &payload)
+		return payload["QueueUrl"]
+	}
+}
+
+func awsCmdSendMessage() {
+	if err := exec.Command(
+		"aws", "sqs",
+		"send-message",
+		"--queue-url", awsCmdQueueURL(),
+		"--message-body", TestMessage,
+		"--region", AWSRegion,
+		"--endpoint-url", CustomAWSEndpointURL).Run(); err != nil {
+
+		panic(err)
+	}
+}
+
+func awsCmdReceiveMessage() string {
+	if out, err := exec.Command(
+		"aws", "sqs",
+		"receive-message",
+		"--queue-url", awsCmdQueueURL(),
+		"--attribute-names", "body",
+		"--region", AWSRegion,
+		"--endpoint-url", CustomAWSEndpointURL).CombinedOutput(); err != nil {
+
+		panic(err)
+	} else {
+		var payload map[string][]map[string]string
+		json.Unmarshal(out, &payload)
+		return payload["Messages"][0]["Body"]
+	}
+}
+
+func awsCmdQueueCount() int {
+	if out, err := exec.Command(
+		"aws", "sqs",
+		"get-queue-attributes",
+		"--queue-url", awsCmdQueueURL(),
+		"--attribute-name", "ApproximateNumberOfMessages",
+		"--region", AWSRegion,
+		"--endpoint-url", CustomAWSEndpointURL).CombinedOutput(); err != nil {
+
+		panic(err)
+	} else {
+		var payload map[string]map[string]string
+		json.Unmarshal(out, &payload)
+		rvalue, _ := strconv.Atoi(payload["Attributes"]["ApproximateNumberOfMessages"])
+		return rvalue
+	}
+}
+
+func TestSQSNewAndReady(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	// two tests, good and bad
+
+	// GOOD
+
+	// ACTION
+	client, err := New()
+	ready := client.Ready()
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.True(t, ready)
+
+	// BAD
+
+	os.Unsetenv("AWS_REGION")
+
+	// ACTION
+	client, err = New()
+	ready = client.Ready()
+
+	// ASSERT
+	assert.NotNil(t, err)
+	assert.False(t, ready)
+}
+
+func TestSQSNewWithRetries(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	// ACTION
+	_, err := NewWithMaxRetries(2)
+
+	// ASSERT
+	assert.Nil(t, err)
+
+	// ARRAGE
+	os.Unsetenv("AWS_REGION")
+
+	// ACTION
+	_, err = NewWithMaxRetries(2)
+
+	// ASSERT
+	assert.NotNil(t, err)
+}
+
+func TestSQSReceive(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	awsCmdSendMessage()
+
+	client, err := New()
+	require.Nil(t, err, fmt.Sprintf("Error creating sqs client: %v", err))
+
+	// ACTION
+	receivedMessage, err := client.Receive(awsCmdQueueURL(), 1)
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.Equal(t, TestMessage, receivedMessage.Body)
+}
+
+func TestSQSReceiveWithAttributes(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	awsCmdSendMessage()
+
+	client, err := New()
+	require.Nil(t, err, fmt.Sprintf("Error creating sqs client: %v", err))
+
+	// ACTION
+	receivedMessage, err := client.ReceiveWithAttributes(
+		awsCmdQueueURL(), 1, []types.QueueAttributeName{"All"})
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.True(t, len(receivedMessage.Attributes) > 0)
+}
+
+func TestSQSDelete(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	awsCmdSendMessage()
+	require.Equal(t, 1, awsCmdQueueCount())
+
+	client, err := New()
+	require.Nil(t, err, fmt.Sprintf("Error creating sqs client: %v", err))
+
+	receivedMessage, err := client.Receive(awsCmdQueueURL(), 1)
+	require.Nil(t, err, fmt.Sprintf("Error receiving test message: %v", err))
+
+	// ACTION
+	err = client.Delete(awsCmdQueueURL(), receivedMessage.ReceiptHandle)
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.Equal(t, 0, awsCmdQueueCount())
+}
+
+func TestSQSSend(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	client, err := New()
+	require.Nil(t, err, fmt.Sprintf("Error creating sqs client: %v", err))
+
+	// ACTION
+	err = client.Send(awsCmdQueueURL(), TestMessage)
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.Equal(t, TestMessage, awsCmdReceiveMessage())
+}
+
+func TestSQSSendWithDelay(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	client, err := New()
+	require.Nil(t, err, fmt.Sprintf("Error creating sqs client: %v", err))
+
+	// ACTION
+	err = client.SendWithDelay(awsCmdQueueURL(), TestMessage, 4) // delay seconds
+	time.Sleep(2 * time.Second)
+	messageCountBeforeDelay := awsCmdQueueCount()
+	time.Sleep(3 * time.Second)
+	messageCountAfterDelay := awsCmdQueueCount()
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.Equal(t, 0, messageCountBeforeDelay)
+	assert.Equal(t, 1, messageCountAfterDelay)
+}
+
+func TestGetQueueUrl(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	client, err := New()
+	require.Nil(t, err, fmt.Sprintf("Error creating sqs client: %v", err))
+
+	// ACTION
+	queueURL, err := client.GetQueueUrl(TestQueue)
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.Equal(t, awsCmdQueueURL(), queueURL)
+}

--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/lib/pq v1.3.0
+	github.com/stretchr/testify v1.3.0
 	google.golang.org/protobuf v1.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -80,7 +80,6 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=


### PR DESCRIPTION
## Proposed Changes
Allow use of a custom AWS Endpoint URL. There are several reasons why this might be desirable, but for our particular use-case, it's to allow use of LocalStack AWS services.

Changes proposed in this pull request:

- Changes mostly follow https://aws.github.io/aws-sdk-go-v2/docs/configuring-sdk/endpoints/, and introduces an `EndpointResolver` when generating a configuration

## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [ ] This is a minor change (meta data, bug fix, improve test coverage etc).
- [X] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

In theory, this should be completely new functionality and nothing should break.