### PR TITLE
Weft asset changes for JS module compatibility.

### DIFF
--- a/weft/assets.go
+++ b/weft/assets.go
@@ -151,16 +151,6 @@ func AssetHandler(r *http.Request, h http.Header, b *bytes.Buffer) error {
 	return nil
 }
 
-// AssetPath returns the finger printed path for path e.g., `/assets/bootstrap/hello.css`
-// returns `/assets/bootstrap/1fdd2266-hello.css`.
-func AssetPath(path string) string {
-	return assets[path].path
-}
-
-func SRIforPath(path string) string {
-	return assets[path].path
-}
-
 // loadAsset loads file and finger prints it with a sha256 hash.  prefix is stripped
 // from path members in the returned asset.
 func loadAsset(file, prefix string) (*asset, error) {

--- a/weft/assets.go
+++ b/weft/assets.go
@@ -193,7 +193,7 @@ func CreateImportMap(nonce string) (template.HTML, error) {
 	importMap = strings.TrimSuffix(importMap, ",")
 	importMap += "\n\t\t\t}\n\t\t}\n\t</script>"
 
-	return template.HTML(importMap), nil
+	return template.HTML(importMap), nil //nolint:gosec
 }
 
 // AssetHandler serves assets from the local directory `assets/assets`.  Assets are loaded from this

--- a/weft/assets.go
+++ b/weft/assets.go
@@ -34,10 +34,10 @@ func init() {
 }
 
 /*
-	As part of Subresource Integrity we need to calculate the hash of the asset, we do this when the asset is loaded into memory
-	This should only be used for files that are stored alongside the server, as remote files could be tampered with and we'd still
-	just calculate the hash.
-	Externally hosted files should have a precalculated SRI
+As part of Subresource Integrity we need to calculate the hash of the asset, we do this when the asset is loaded into memory
+This should only be used for files that are stored alongside the server, as remote files could be tampered with and we'd still
+just calculate the hash.
+Externally hosted files should have a precalculated SRI
 */
 func calcSRIhash(b []byte) (string, error) {
 	var buf bytes.Buffer
@@ -121,8 +121,8 @@ func CreateSubResourceTag(args ...string) (template.HTML, error) {
 // Assets are served at the path `/assets/...` and can be also be served with a hashed path which finger prints the asset
 // for uniqueness for caching e.g.,
 //
-//    /assets/bootstrap/hello.css
-//    /assets/bootstrap/1fdd2266-hello.css
+//	/assets/bootstrap/hello.css
+//	/assets/bootstrap/1fdd2266-hello.css
 //
 // The finger printed path can be looked up with AssetPath.
 func AssetHandler(r *http.Request, h http.Header, b *bytes.Buffer) error {
@@ -189,9 +189,9 @@ func loadAsset(file, prefix string) (*asset, error) {
 
 	// these types should appear in weft.compressibleMimes as appropriate
 	switch suffix {
-	case "js", "mjs":
+	case "js", "mjs", "map":
 		a.mime = "text/javascript"
-	case "css", "map":
+	case "css":
 		a.mime = "text/css"
 	case "jpeg", "jpg":
 		a.mime = "image/jpeg"

--- a/weft/assets.go
+++ b/weft/assets.go
@@ -89,8 +89,10 @@ func createSubResourceTag(a *asset, nonce string) (string, error) {
 		} else {
 			return fmt.Sprintf(`<script src="%s" type="module" integrity="%s"></script>`, a.hashedPath, a.sri), nil
 		}
-	case "css", "map":
+	case "css":
 		return fmt.Sprintf(`<link rel="stylesheet" href="%s" integrity="%s">`, a.hashedPath, a.sri), nil
+	case "map":
+		return fmt.Sprintf(`<link rel="stylesheet" href="%s" integrity="%s">`, a.path, a.sri), nil
 	default:
 		return "", fmt.Errorf("cannot create an embedded resource tag for mime: '%v'", a.mime)
 	}

--- a/weft/assets.go
+++ b/weft/assets.go
@@ -38,12 +38,10 @@ func init() {
 	assetError = initAssets("assets/assets", "assets")
 }
 
-/*
-As part of Subresource Integrity we need to calculate the hash of the asset, we do this when the asset is loaded into memory
-This should only be used for files that are stored alongside the server, as remote files could be tampered with and we'd still
-just calculate the hash.
-Externally hosted files should have a precalculated SRI
-*/
+// As part of Subresource Integrity we need to calculate the hash of the asset, we do this when the asset is loaded into memory
+// This should only be used for files that are stored alongside the server, as remote files could be tampered with and we'd still
+// just calculate the hash.
+// Externally hosted files should have a precalculated SRI
 func calcSRIhash(b []byte) (string, error) {
 	var buf bytes.Buffer
 
@@ -58,9 +56,7 @@ func calcSRIhash(b []byte) (string, error) {
 	return "sha384-" + buf.String(), nil
 }
 
-/**
- * create a random nonce string of specified length
- */
+// getCspNonce creates a random nonce string of specified length.
 func getCspNonce(len int) (string, error) {
 	b := make([]byte, len)
 	if _, err := io.ReadFull(rand.Reader, b); err != nil {
@@ -76,11 +72,8 @@ func getCspNonce(len int) (string, error) {
 	return buf.String(), nil
 }
 
-/**
- * Wrapped by the following function to allow testing
- * @param nonce: nonce to be added as script attribute
- * @param attr: "defer" or "async" attribute.
- */
+// createSubResourceTag returns a script tag as a string, based on the given
+// asset, nonce, and script loading attribute (ie: "defer" or "async")
 func createSubResourceTag(a *asset, nonce, attr string) (string, error) {
 	switch a.fileType {
 	case "js":
@@ -116,12 +109,10 @@ func createSubResourcePreloadTag(a *asset, nonce string) (string, error) {
 	}
 }
 
-/*
- * Generates a tag for a resource with the hashed path and SRI hash.
- * Returns a template.HTML so it won't throw warnings with golangci-lint
- * @param args: 1~3 strings: 1. the asset path, 2. nonce for script attribute,
- * 3. additional script loading attribute ("defer" or "async")
- */
+// CreateSubResourceTag generates a tag for a resource with the hashed path and SRI hash.
+// Returns a template.HTML so it won't throw warnings with golangci-lint.
+// args can be 1~3 strings: 1. the asset path, 2. nonce for script attribute,
+// 3. script loading attribute ("defer" or "async").
 func CreateSubResourceTag(args ...string) (template.HTML, error) {
 	var nonce string
 	if len(args) > 1 {

--- a/weft/assets.go
+++ b/weft/assets.go
@@ -13,6 +13,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -158,6 +159,33 @@ func CreateSubResourcePreload(args ...string) (template.HTML, error) {
 	s, err := createSubResourcePreloadTag(a, nonce)
 
 	return template.HTML(s), err //nolint:gosec
+}
+
+// CreateImportMap generates an import map script tag which maps asset filenames to their
+// respectful hash-prefixed path name. eg:
+//
+//	<script type="importmap" nonce="abcdefghijklmnop">
+//		{
+//			"imports":{
+//				"geonet-map.mjs":"/assets/js/77da7c4e-geonet-map.mjs"
+//			}
+//		}
+//	</script>
+func CreateImportMap(nonce string) (template.HTML, error) {
+
+	importMap := fmt.Sprintf("<script type=\"importmap\" nonce=\"%s\">\n\t\t{\n\t\t\t\"imports\":{", nonce)
+
+	for k, v := range assetHashes {
+		if !strings.HasSuffix(k, ".mjs") {
+			continue
+		}
+		filename := path.Base(k)
+		importMap += fmt.Sprintf("\n\t\t\t\t\"%s\":\"%s\",", filename, v)
+	}
+	importMap = strings.TrimSuffix(importMap, ",")
+	importMap += "\n\t\t\t}\n\t\t}\n\t</script>"
+
+	return template.HTML(importMap), nil
 }
 
 // AssetHandler serves assets from the local directory `assets/assets`.  Assets are loaded from this

--- a/weft/assets.go
+++ b/weft/assets.go
@@ -170,7 +170,7 @@ func CreateSubResourcePreload(args ...string) (template.HTML, error) {
 //		}
 //	}
 //	</script>
-func CreateImportMap(nonce string) (template.HTML, error) {
+func CreateImportMap(nonce string) template.HTML {
 
 	importMapping := make(map[string]string, 0)
 	for k, v := range assetHashes {
@@ -181,11 +181,11 @@ func CreateImportMap(nonce string) (template.HTML, error) {
 		importMapping[filename] = v
 	}
 	if len(importMapping) == 0 {
-		return template.HTML(""), errors.New("no module files found, import map not required.")
+		return template.HTML("")
 	}
 	importMap := createImportMapTag(importMapping, nonce)
 
-	return template.HTML(importMap), nil //nolint:gosec
+	return template.HTML(importMap) //nolint:gosec
 }
 
 // createImportMapTag returns the <script> tag of type "importmap" to faciliate browser with

--- a/weft/assets_test.go
+++ b/weft/assets_test.go
@@ -96,20 +96,24 @@ func TestCreateSubResourceTag(t *testing.T) {
 
 	work := []struct {
 		nonce    string
+		attr     string
 		path     string
 		expected string
 	}{
 		{"",
+			"",
 			"testdata/leaflet.css",
-			`<link rel="stylesheet" href="/07800b98-leaflet.css" integrity="sha384-9oKBsxAYdVVBJcv3hwG8RjuoJhw9GwYLqXdQRDxi2q0t1AImNHOap8y6Qt7REVd4">`,
+			`<link rel="stylesheet" href="/07800b98-leaflet.css" integrity="sha384-9oKBsxAYdVVBJcv3hwG8RjuoJhw9GwYLqXdQRDxi2q0t1AImNHOap8y6Qt7REVd4" >`,
 		},
 		{"abcdefgh",
+			"async",
 			"testdata/gnss-map-plot.js",
-			`<script src="/e83a0b0f-gnss-map-plot.js" type="text/javascript" integrity="sha384-haxRijtRHhpn6nbt+JNpioqOj0AwB+THIaVdUZ34R9sQrQL2vmf/pn6GPnQq+AI1" nonce="abcdefgh"></script>`,
+			`<script src="/e83a0b0f-gnss-map-plot.js" type="text/javascript" integrity="sha384-haxRijtRHhpn6nbt+JNpioqOj0AwB+THIaVdUZ34R9sQrQL2vmf/pn6GPnQq+AI1" nonce="abcdefgh" async></script>`,
 		},
 		{"ijklmnop",
+			"defer",
 			"testdata/test.mjs",
-			`<script src="/3616e4a4-test.mjs" type="module" integrity="sha384-yL9nK0JVp9FW9oAfkQ2kQC/9CcuAMK4vmyb8q+TY2SokmBFflIxJpZJ6Nk8Xqw5r" nonce="ijklmnop"></script>`,
+			`<script src="/3616e4a4-test.mjs" type="module" integrity="sha384-yL9nK0JVp9FW9oAfkQ2kQC/9CcuAMK4vmyb8q+TY2SokmBFflIxJpZJ6Nk8Xqw5r" nonce="ijklmnop" defer></script>`,
 		},
 	}
 
@@ -121,7 +125,7 @@ func TestCreateSubResourceTag(t *testing.T) {
 				t.Error(err)
 			}
 
-			tag, err := createSubResourceTag(a, w.nonce)
+			tag, err := createSubResourceTag(a, w.nonce, w.attr)
 			if err != nil {
 				t.Fatalf("Couldn't create embedded resource tag: %v", err)
 			}

--- a/weft/assets_test.go
+++ b/weft/assets_test.go
@@ -132,3 +132,42 @@ func TestCreateSubResourceTag(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateSubResourcePreloadTag(t *testing.T) {
+	err := initAssets("testdata", "testdata")
+	if err != nil {
+		t.Error(err)
+	}
+
+	work := []struct {
+		nonce    string
+		path     string
+		expected string
+	}{
+		{"",
+			"testdata/test.mjs",
+			`<link rel="modulepreload" href="/3616e4a4-test.mjs" integrity="sha384-yL9nK0JVp9FW9oAfkQ2kQC/9CcuAMK4vmyb8q+TY2SokmBFflIxJpZJ6Nk8Xqw5r"/>`,
+		},
+		{"abcdefg",
+			"testdata/test.mjs",
+			`<link rel="modulepreload" href="/3616e4a4-test.mjs" integrity="sha384-yL9nK0JVp9FW9oAfkQ2kQC/9CcuAMK4vmyb8q+TY2SokmBFflIxJpZJ6Nk8Xqw5r" nonce="abcdefg"/>`,
+		},
+	}
+
+	for _, w := range work {
+		t.Run(w.path, func(t *testing.T) {
+
+			a, err := loadAsset(w.path, "testdata")
+			if err != nil {
+				t.Fatal(err)
+			}
+			tag, err := createSubResourcePreloadTag(a, w.nonce)
+			if err != nil {
+				t.Errorf("Couldn't create embedded resource preload tag: %v", err)
+			}
+			if tag != w.expected {
+				t.Errorf("output tag '%v' did not equal epected '%v'", tag, w.expected)
+			}
+		})
+	}
+}

--- a/weft/assets_test.go
+++ b/weft/assets_test.go
@@ -175,3 +175,57 @@ func TestCreateSubResourcePreloadTag(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateImportTag(t *testing.T) {
+	err := initAssets("testdata", "testdata")
+	if err != nil {
+		t.Error(err)
+	}
+
+	work := []struct {
+		testName      string
+		nonce         string
+		importMapping map[string]string
+		expected      string
+	}{
+		{
+			"No nonce, one module file",
+			"",
+			map[string]string{
+				"test.mjs": "/assets/js/hashprefix-test.mjs",
+			},
+			`<script type="importmap">
+{
+	"imports":{
+		"test.mjs":"/assets/js/hashprefix-test.mjs"
+	}
+}
+</script>`,
+		},
+		{
+			"Nonce present, two module files",
+			"abcdefg",
+			map[string]string{
+				"test1.mjs": "/assets/js/hashprefix-test1.mjs",
+				"test2.mjs": "/assets/js/hashprefix-test2.mjs",
+			},
+			`<script type="importmap" nonce="abcdefg">
+{
+	"imports":{
+		"test1.mjs":"/assets/js/hashprefix-test1.mjs",
+		"test2.mjs":"/assets/js/hashprefix-test2.mjs"
+	}
+}
+</script>`,
+		},
+	}
+
+	for _, w := range work {
+		t.Run(w.testName, func(t *testing.T) {
+			tag := createImportMapTag(w.importMapping, w.nonce)
+			if tag != w.expected {
+				t.Errorf("import map tag\n '%v' did not equal expected\n '%v'", tag, w.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Reference: https://github.com/GeoNet/tickets/issues/13314

Changes proposed in this pull request:

- Only add hash-prefixed assets to asset map on init, to avoid accidental loading of old, non-hash prefixed and therefore cached files.
- Add functionality for creating importmap and preloadmodule tags. Allows use of JS modules with existing requirements of SRI on all assets, and hash-prefixed asset files for cache-busting.
- Add option for script tag to load with `defer` or `async`
- Other small adjustments.

## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [ ] This is a minor change (meta data, bug fix, improve test coverage etc).
- [x] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*