### PR TITLE
change strict hashedPath requirement on assets

### DIFF
--- a/weft/assets.go
+++ b/weft/assets.go
@@ -337,14 +337,8 @@ func initAssets(dir, prefix string) error {
 			if err != nil {
 				return err
 			}
-
-			switch a.fileType {
-			case "js", "mjs", "css":
-				assets[a.hashedPath] = a
-			default:
-				assets[a.hashedPath] = a
-				assets[a.path] = a
-			}
+			assets[a.hashedPath] = a
+			assets[a.path] = a
 			assetHashes[a.path] = a.hashedPath
 		}
 	}


### PR DESCRIPTION
Strict requirement for assets files (`js/mjs/css`) to be accessed only with a hash prefix is causing the current main branch of `www-geonet` not working, so removed it, can be added back (but not necessary) when the [import map implementation](https://github.com/GeoNet/www-geonet/commit/7b3354f57bfb53892d91e909478a272e968145af) is merged.

## Proposed Changes

Resolves #.

Changes proposed in this pull request:



## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*