### PR TITLE
feat(test): make test less approximate

### DIFF
--- a/aws/sqs/sqs_integration_test.go
+++ b/aws/sqs/sqs_integration_test.go
@@ -256,16 +256,22 @@ func TestSQSSendWithDelay(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("Error creating sqs client: %v", err))
 
 	// ACTION
-	err = client.SendWithDelay(awsCmdQueueURL(), testMessage, 4) // delay seconds
-	time.Sleep(2 * time.Second)
-	messageCountBeforeDelay := awsCmdQueueCount()
-	time.Sleep(3 * time.Second)
-	messageCountAfterDelay := awsCmdQueueCount()
+	err = client.SendWithDelay(awsCmdQueueURL(), testMessage, 5) // delay seconds
+	assert.Nil(t, err)                                           // fail fast here to avoid loop queue check
+
+	start := time.Now()
+	timeout := 10 * time.Second
+	for awsCmdQueueCount() < 1 {
+		time.Sleep(500 * time.Millisecond)
+		if time.Since(start) > timeout {
+			break
+		}
+	}
+	timeElapsed := time.Since(start)
 
 	// ASSERT
-	assert.Nil(t, err)
-	assert.Equal(t, 0, messageCountBeforeDelay)
-	assert.Equal(t, 1, messageCountAfterDelay)
+	assert.True(t, timeElapsed > 5*time.Second)
+	assert.True(t, timeElapsed < timeout)
 }
 
 func TestGetQueueUrl(t *testing.T) {


### PR DESCRIPTION
Test is sometimes passing, sometimes not in Github Actions.
This PR improves the test robustness against the variable amount of time the utility function `awsCmdQueueCount` takes.

Note: the test is still somewhat approximate, it doesn't absolutely prove that the delay time was indeed as expected, but it gives a good enough test.