### PR TITLE
chore: fix s3 headobject not found checking

### DIFF
--- a/aws/s3/s3.go
+++ b/aws/s3/s3.go
@@ -216,11 +216,15 @@ func (s *S3) GetMeta(bucket, key, version string) (Meta, error) {
 
 	res, err := s.client.HeadObject(context.TODO(), &input)
 	if err != nil {
-		var nf *types.NotFound
-		if errors.As(err, &nf) {
-			return Meta{}, nil
+		if err != nil {
+			var ae smithy.APIError
+			if errors.As(err, &ae) {
+				if ae.ErrorCode() == "NotFound" {
+					return Meta{}, nil
+				}
+			}
+			return Meta{}, err
 		}
-		return Meta{}, err
 	}
 
 	return res.Metadata, nil

--- a/aws/s3/s3_integration_test.go
+++ b/aws/s3/s3_integration_test.go
@@ -381,6 +381,13 @@ func TestS3GetMeta(t *testing.T) {
 	// ASSERT
 	assert.Nil(t, err)
 	assert.Equal(t, testMetaValue, meta[testMetaKey])
+
+	// for non existing object, we want an empty result instead of not found error
+	meta, err = client.GetMeta(testBucket, fmt.Sprintf("%s.%d", testObjectKey, time.Now().Unix()), "")
+
+	// ASSERT
+	assert.Nil(t, err)
+	assert.Empty(t, meta)
 }
 
 func TestS3GetContentSizeTime(t *testing.T) {


### PR DESCRIPTION
## Proposed Changes

Resolves #.

Changes proposed in this pull request:

- Existing NotFound check for `s3.HeadObject` call doesn't work. Not follow the same way as `s3.Exists()`.
-
-

## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide
