### PR TITLE
fix: set DisableInitialHostLookup to false

### DIFF
--- a/aws/keyspaces/keyspaces.go
+++ b/aws/keyspaces/keyspaces.go
@@ -68,8 +68,11 @@ func New(host, certPath string) (Keyspaces, error) {
 		}
 		// Override default Consistency to LocalQuorum
 		cluster.Consistency = gocql.LocalQuorum
-		// Disable initial host lookup
-		cluster.DisableInitialHostLookup = true
+
+		// Enable initial host lookup.
+		// see https://github.com/gocql/gocql/issues/915
+		// When set to true, we were seeing this error intermittently.
+		cluster.DisableInitialHostLookup = false
 	}
 
 	// Create session.

--- a/aws/keyspaces/keyspaces.go
+++ b/aws/keyspaces/keyspaces.go
@@ -54,6 +54,9 @@ func New(host, certPath string) (Keyspaces, error) {
 	cluster := gocql.NewCluster(host)
 	ksClient.cluster = cluster
 
+	// Set port.
+	cluster.Port = 9142
+
 	// When host is localhost, for example in a test environment, we don't need these settings.
 	if host != "localhost" {
 		authenticator, err := generateAuthenticator()


### PR DESCRIPTION
In an effort to prevent the intermittent error seen in https://github.com/GeoNet/tickets/issues/15591

Other relevant tickets:
https://github.com/gocql/gocql/issues/1721
https://github.com/gocql/gocql/issues/915


## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*