### PR TITLE
fix: only set keyspaces port if not localhost

### DIFF
--- a/aws/keyspaces/keyspaces.go
+++ b/aws/keyspaces/keyspaces.go
@@ -54,11 +54,12 @@ func New(host, certPath string) (Keyspaces, error) {
 	cluster := gocql.NewCluster(host)
 	ksClient.cluster = cluster
 
-	// Set port.
-	cluster.Port = 9142
-
 	// When host is localhost, for example in a test environment, we don't need these settings.
 	if host != "localhost" {
+
+		// Set port.
+		cluster.Port = 9142
+
 		authenticator, err := generateAuthenticator()
 		if err != nil {
 			return ksClient, err


### PR DESCRIPTION
Test environments don't work if port is set to 9142 explicitly

Reference: https://github.com/GeoNet/tickets/issues/15591

## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*