### PR TITLE
fix: use AWS_ENDPOINT_URL env var

### DIFF
--- a/aws/s3/s3.go
+++ b/aws/s3/s3.go
@@ -94,7 +94,7 @@ func getConfig() (aws.Config, error) {
 	var cfg aws.Config
 	var err error
 
-	if awsEndpoint := os.Getenv("CUSTOM_AWS_ENDPOINT_URL"); awsEndpoint != "" {
+	if awsEndpoint := os.Getenv("AWS_ENDPOINT_URL"); awsEndpoint != "" {
 		customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
 			return aws.Endpoint{
 				PartitionID:       "aws",

--- a/aws/s3/s3_integration_test.go
+++ b/aws/s3/s3_integration_test.go
@@ -40,14 +40,12 @@ func setAwsEnv() {
 	os.Setenv("AWS_REGION", testRegion)
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "test")
 	os.Setenv("AWS_ACCESS_KEY_ID", "test")
+	os.Setenv("AWS_ENDPOINT_URL", customAWSEndpoint)
 }
 
 func setup() {
 	// setup environment variable to run AWS CLI/SDK
 	setAwsEnv()
-
-	// setup environment variable to access LocalStack
-	os.Setenv("CUSTOM_AWS_ENDPOINT_URL", customAWSEndpoint)
 
 	// create bucket
 	if err := exec.Command( //nolint:gosec
@@ -56,7 +54,7 @@ func setup() {
 		"--bucket", testBucket,
 		"--create-bucket-configuration", fmt.Sprintf(
 			"{\"LocationConstraint\": \"%v\"}", testRegion),
-		"--endpoint-url", customAWSEndpoint).Run(); err != nil {
+	).Run(); err != nil {
 
 		panic(err)
 	}
@@ -69,7 +67,7 @@ func teardown() {
 		"aws", "s3",
 		"rb", fmt.Sprintf("s3://%v", testBucket),
 		"--force",
-		"--endpoint-url", customAWSEndpoint).Run(); err != nil {
+	).Run(); err != nil {
 
 		panic(err)
 	}
@@ -93,7 +91,7 @@ func awsCmdPopulateBucket() {
 		"--key", testObjectKey,
 		"--body", testDataFilepath,
 		"--metadata", fmt.Sprintf("%v=%v", testMetaKey, testMetaValue),
-		"--endpoint-url", customAWSEndpoint).Run(); err != nil {
+	).Run(); err != nil {
 
 		panic(err)
 	}
@@ -105,7 +103,7 @@ func awsCmdExists(key string) bool {
 		"head-object",
 		"--bucket", testBucket,
 		"--key", key,
-		"--endpoint-url", customAWSEndpoint).Run(); err != nil {
+	).Run(); err != nil {
 
 		return false
 	}
@@ -118,7 +116,7 @@ func awsCmdPutKey(key string) {
 		"put-object",
 		"--bucket", testBucket,
 		"--key", key,
-		"--endpoint-url", customAWSEndpoint).Run(); err != nil {
+	).Run(); err != nil {
 
 		panic(err)
 	}
@@ -139,7 +137,7 @@ func awsCmdPutKeys(keys []string) {
 	if err := exec.Command(
 		"aws", "s3",
 		"sync", tmpDir, fmt.Sprintf("s3://%v", testBucket),
-		"--endpoint-url", customAWSEndpoint).Run(); err != nil {
+	).Run(); err != nil {
 
 		panic(err)
 	}
@@ -160,8 +158,7 @@ func awsCmdMeta() awsMeta {
 		"aws", "s3api",
 		"head-object",
 		"--bucket", testBucket,
-		"--key", testObjectKey,
-		"--endpoint-url", customAWSEndpoint)
+		"--key", testObjectKey)
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -197,7 +194,6 @@ func awsCmdGetTestObject() string {
 		"get-object",
 		"--bucket", testBucket,
 		"--key", testObjectKey,
-		"--endpoint-url", customAWSEndpoint,
 		testDataFilepath).Run(); err != nil {
 		panic(err)
 	}

--- a/aws/sns/sns.go
+++ b/aws/sns/sns.go
@@ -50,7 +50,7 @@ func getConfig() (aws.Config, error) {
 	var cfg aws.Config
 	var err error
 
-	if awsEndpoint := os.Getenv("CUSTOM_AWS_ENDPOINT_URL"); awsEndpoint != "" {
+	if awsEndpoint := os.Getenv("AWS_ENDPOINT_URL"); awsEndpoint != "" {
 		customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
 			return aws.Endpoint{
 				PartitionID:   "aws",

--- a/aws/sns/sns_integration_test.go
+++ b/aws/sns/sns_integration_test.go
@@ -32,7 +32,7 @@ func setup(createQueue, createTopic bool) (string, string) {
 	os.Setenv("AWS_REGION", awsRegion)
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "test")
 	os.Setenv("AWS_ACCESS_KEY_ID", "test")
-	os.Setenv("CUSTOM_AWS_ENDPOINT_URL", customAWSEndpointURL)
+	os.Setenv("AWS_ENDPOINT_URL", customAWSEndpointURL)
 
 	var queueArn, topicArn string
 	if createQueue {
@@ -54,7 +54,7 @@ func teardown(queueArn, topicArn string) {
 	os.Unsetenv("AWS_REGION")
 	os.Unsetenv("AWS_SECRET_ACCESS_KEY")
 	os.Unsetenv("AWS_ACCESS_KEY_ID")
-	os.Unsetenv("CUSTOM_AWS_ENDPOINT_URL")
+	os.Unsetenv("AWS_ENDPOINT_URL")
 }
 
 func TestSNSNewAndReady(t *testing.T) {
@@ -206,7 +206,6 @@ func awsCmdCheckQueueSubscribedToTopic(topicArn, queueArn, subscriptionArn strin
 		"list-subscriptions-by-topic",
 		"--topic-arn", topicArn,
 		"--region", awsRegion,
-		"--endpoint-url", customAWSEndpointURL,
 		"--output", "json").CombinedOutput(); err != nil {
 
 		panic(err)
@@ -231,7 +230,7 @@ func awsCmdQueueURL(name string) string {
 		"get-queue-url",
 		"--queue-name", name,
 		"--region", awsRegion,
-		"--endpoint-url", customAWSEndpointURL).CombinedOutput(); err != nil {
+	).CombinedOutput(); err != nil {
 
 		panic(err)
 	} else {
@@ -248,7 +247,7 @@ func awsCmdReceiveMessage(name string) string {
 		"--queue-url", awsCmdQueueURL(name),
 		"--attribute-names", "body",
 		"--region", awsRegion,
-		"--endpoint-url", customAWSEndpointURL).CombinedOutput(); err != nil {
+	).CombinedOutput(); err != nil {
 
 		panic(err)
 	} else {
@@ -267,7 +266,6 @@ func awsCmdGetQueueArn(url string) string {
 		"get-queue-attributes",
 		"--queue-url", url,
 		"--attribute-names", "QueueArn",
-		"--endpoint-url", customAWSEndpointURL,
 		"--region", awsRegion,
 		"--query", "Attributes.QueueArn",
 		"--output", "text").CombinedOutput()
@@ -283,7 +281,6 @@ func awsCmdCreateQueue(name string) string {
 		"aws", "sqs",
 		"create-queue",
 		"--queue-name", name,
-		"--endpoint-url", customAWSEndpointURL,
 		"--region", awsRegion,
 		"--query", "QueueUrl",
 		"--output", "text").CombinedOutput()
@@ -299,7 +296,6 @@ func awsCmdCreateTopic(name string) string {
 		"aws", "sns",
 		"create-topic",
 		"--name", name,
-		"--endpoint-url", customAWSEndpointURL,
 		"--region", awsRegion,
 		"--query", "TopicArn",
 		"--output", "text").CombinedOutput()
@@ -315,7 +311,6 @@ func awsCmdDeleteQueue(name string) {
 		"aws", "sqs",
 		"delete-queue",
 		"--queue-url", awsCmdQueueURL(name),
-		"--endpoint-url", customAWSEndpointURL,
 		"--region", awsRegion).Run(); err != nil {
 
 		panic(err)
@@ -327,7 +322,6 @@ func awsCmdDeleteTopic(arn string) {
 		"aws", "sns",
 		"delete-topic",
 		"--topic-arn", arn,
-		"--endpoint-url", customAWSEndpointURL,
 		"--region", awsRegion).Run(); err != nil {
 
 		panic(err)
@@ -341,7 +335,6 @@ func awsCmdSubscribeQueueToTopic(topicArn, queueArn string) {
 		"--topic-arn", topicArn,
 		"--protocol", "sqs",
 		"--notification-endpoint", queueArn,
-		"--endpoint-url", customAWSEndpointURL,
 		"--region", awsRegion).Run(); err != nil {
 
 		panic(err)
@@ -355,7 +348,6 @@ func awsCmdCheckTopicAttribute(arn, attribute, expectedValue string) bool {
 		"get-topic-attributes",
 		"--topic-arn", arn,
 		"--region", awsRegion,
-		"--endpoint-url", customAWSEndpointURL,
 		"--output", "json").CombinedOutput(); err != nil {
 		panic(err)
 	} else {
@@ -380,7 +372,6 @@ func awsCmdCheckTopicExists(arn string) bool {
 		"aws", "sns",
 		"list-topics",
 		"--region", awsRegion,
-		"--endpoint-url", customAWSEndpointURL,
 		"--output", "json").CombinedOutput(); err != nil {
 
 		panic(err)

--- a/aws/sqs/sqs.go
+++ b/aws/sqs/sqs.go
@@ -62,7 +62,7 @@ func getConfig() (aws.Config, error) {
 	var cfg aws.Config
 	var err error
 
-	if awsEndpoint := os.Getenv("CUSTOM_AWS_ENDPOINT_URL"); awsEndpoint != "" {
+	if awsEndpoint := os.Getenv("AWS_ENDPOINT_URL"); awsEndpoint != "" {
 		customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) {
 			return aws.Endpoint{
 				PartitionID:   "aws",

--- a/aws/sqs/sqs_integration_test.go
+++ b/aws/sqs/sqs_integration_test.go
@@ -32,7 +32,7 @@ func setup() {
 	os.Setenv("AWS_REGION", awsRegion)
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "test")
 	os.Setenv("AWS_ACCESS_KEY_ID", "test")
-	os.Setenv("CUSTOM_AWS_ENDPOINT_URL", customAWSEndpointURL)
+	os.Setenv("AWS_ENDPOINT_URL", customAWSEndpointURL)
 
 	// create queue
 	awsCmdCreateQueue(testQueue)
@@ -44,7 +44,7 @@ func teardown() {
 		"delete-queue",
 		"--queue-url", awsCmdQueueURL(),
 		"--region", awsRegion,
-		"--endpoint-url", customAWSEndpointURL).Run(); err != nil {
+	).Run(); err != nil {
 
 		panic(err)
 	}
@@ -55,7 +55,6 @@ func awsCmdCreateQueue(name string) string {
 		"aws", "sqs",
 		"create-queue",
 		"--queue-name", name,
-		"--endpoint-url", customAWSEndpointURL,
 		"--region", awsRegion,
 		"--query", "QueueUrl",
 		"--output", "text").CombinedOutput()
@@ -72,7 +71,7 @@ func awsCmdQueueURL() string {
 		"get-queue-url",
 		"--queue-name", testQueue,
 		"--region", awsRegion,
-		"--endpoint-url", customAWSEndpointURL).CombinedOutput(); err != nil {
+	).CombinedOutput(); err != nil {
 
 		panic(err)
 	} else {
@@ -89,7 +88,7 @@ func awsCmdSendMessage() {
 		"--queue-url", awsCmdQueueURL(),
 		"--message-body", testMessage,
 		"--region", awsRegion,
-		"--endpoint-url", customAWSEndpointURL).Run(); err != nil {
+	).Run(); err != nil {
 
 		panic(err)
 	}
@@ -102,7 +101,7 @@ func awsCmdReceiveMessage() string {
 		"--queue-url", awsCmdQueueURL(),
 		"--attribute-names", "body",
 		"--region", awsRegion,
-		"--endpoint-url", customAWSEndpointURL).CombinedOutput(); err != nil {
+	).CombinedOutput(); err != nil {
 
 		panic(err)
 	} else {
@@ -118,8 +117,7 @@ func awsCmdQueueCount() int {
 		"get-queue-attributes",
 		"--queue-url", awsCmdQueueURL(),
 		"--attribute-name", "ApproximateNumberOfMessages",
-		"--region", awsRegion,
-		"--endpoint-url", customAWSEndpointURL).CombinedOutput(); err != nil {
+		"--region", awsRegion).CombinedOutput(); err != nil {
 
 		panic(err)
 	} else {
@@ -136,7 +134,6 @@ func awsCmdGetQueueArn(url string) string {
 		"get-queue-attributes",
 		"--queue-url", url,
 		"--attribute-names", "QueueArn",
-		"--endpoint-url", customAWSEndpointURL,
 		"--region", awsRegion,
 		"--query", "Attributes.QueueArn",
 		"--output", "text").CombinedOutput()
@@ -152,7 +149,6 @@ func awsCmdDeleteQueue(url string) {
 		"aws", "sqs",
 		"delete-queue",
 		"--queue-url", url,
-		"--endpoint-url", customAWSEndpointURL,
 		"--region", awsRegion).Run(); err != nil {
 
 		panic(err)
@@ -166,7 +162,6 @@ func awsCmdCheckSQSAttribute(url, attribute, expectedValue string) bool {
 		"get-queue-attributes",
 		"--queue-url", url,
 		"--region", awsRegion,
-		"--endpoint-url", customAWSEndpointURL,
 		"--attribute-names", attribute,
 		"--output", "json").CombinedOutput(); err != nil {
 		panic(err)


### PR DESCRIPTION
Reference: https://github.com/GeoNet/tickets/issues/17006

## Proposed Changes

Changes proposed in this pull request:

Replaces `CUSTOM_AWS_ENDPOINT_URL`. The AWS CLI has knowledge of the `AWS_ENDPOINT_URL` and will use this when set, meaning the test code doesn't need to refer to it explicitly with the `--endpoint-url` flag. Setting `AWS_ENDPOINT_URL` to Localstack's url works the same as before.

## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*