### PR TITLE
feat: add method to return underlying sqs client

### DIFF
--- a/aws/sqs/sqs.go
+++ b/aws/sqs/sqs.go
@@ -92,6 +92,11 @@ func (s *SQS) Ready() bool {
 	return s.client != nil
 }
 
+// Client returns the underlying SQS client.
+func (s *SQS) Client() *sqs.Client {
+	return s.client
+}
+
 // Receive receives a raw message or error from the queue.
 // After a successful receive the message will be in flight
 // until it is either deleted or the visibility timeout expires

--- a/aws/sqs/sqs_integration_test.go
+++ b/aws/sqs/sqs_integration_test.go
@@ -206,6 +206,24 @@ func TestCheckQueue(t *testing.T) {
 
 }
 
+func TestSQSClient(t *testing.T) {
+	// ARRANGE
+	setup()
+	defer teardown()
+
+	client, err := New()
+	ready := client.Ready()
+
+	require.Nil(t, err)
+	require.True(t, ready)
+
+	// ACTION
+	underlyingClient := client.Client()
+
+	// ASSERT
+	assert.NotNil(t, underlyingClient)
+}
+
 func TestSQSNewAndReady(t *testing.T) {
 	// ARRANGE
 	setup()


### PR DESCRIPTION


Changes proposed in this pull request:

- Add method to return underlying sqs client. Useful when a wrapper function is not available for a particular use-case, without having to define another client from scratch.

## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [ ] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*