### PR TITLE
fix: change sqs body max size to 1 MiB

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     uses: GeoNet/Actions/.github/workflows/reusable-go-apps.yml@main
     with:
       testSetup: |
-        docker run --name localstack -d --rm -p 4566:4566 -p 4510-4559:4510-4559 docker.io/localstack/localstack:4.0.3
+        docker run --name localstack -d --rm -p 4566:4566 -p 4510-4559:4510-4559 docker.io/localstack/localstack:4.10.0
         echo "waiting for localstack to be ready"
         until curl -v localhost:4566; do
           sleep 1s

--- a/aws/README.md
+++ b/aws/README.md
@@ -1,3 +1,4 @@
 ## Wrapper files for AWS-SDK-GO ##
 
 These files are to simplify how applications interact with the AWS SDK for Go.
+The functions are expected to be in line with the underlying AWS service.

--- a/aws/sqs/sqs.go
+++ b/aws/sqs/sqs.go
@@ -353,7 +353,7 @@ func (s *SQS) SendNBatch(ctx context.Context, queueURL string, bodies []string) 
 
 	const (
 		maxCount = 10
-		maxSize  = 262144 // 256 KiB
+		maxSize  = 1048576 // 1 MiB
 	)
 
 	allErrors := make([]error, 0)

--- a/aws/sqs/sqs_integration_test.go
+++ b/aws/sqs/sqs_integration_test.go
@@ -455,11 +455,8 @@ func TestSendBatch(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("error creating sqs client: %v", err))
 
 	// ACTION
-	var maxBytes int = 262144
-	maxSizeSingleMessage := ""
-	for range maxBytes {
-		maxSizeSingleMessage += "a"
-	}
+	var maxBytes int = 1048576
+	maxSizeSingleMessage := strings.Repeat("a", maxBytes)
 	err = client.SendBatch(context.TODO(), awsCmdQueueURL(), []string{maxSizeSingleMessage})
 
 	// ASSERT
@@ -474,11 +471,8 @@ func TestSendBatch(t *testing.T) {
 	assert.NotNil(t, err)
 
 	// ACTION
-	var maxHalfBytes int = 131072
-	maxHalfSizeMessage := ""
-	for range maxHalfBytes {
-		maxHalfSizeMessage += "a"
-	}
+	var maxHalfBytes int = 524288
+	maxHalfSizeMessage := strings.Repeat("a", maxHalfBytes)
 	err = client.SendBatch(context.TODO(), awsCmdQueueURL(), []string{maxHalfSizeMessage, maxHalfSizeMessage})
 
 	// ASSERT
@@ -531,11 +525,8 @@ func TestSendNBatch(t *testing.T) {
 	require.Nil(t, err, fmt.Sprintf("error creating sqs client: %v", err))
 
 	// ACTION
-	var maxBytes int = 262144
-	maxSizeSingleMessage := ""
-	for range maxBytes {
-		maxSizeSingleMessage += "a"
-	}
+	var maxBytes int = 1048576
+	maxSizeSingleMessage := strings.Repeat("a", maxBytes)
 	batchesSent, err := client.SendNBatch(context.TODO(), awsCmdQueueURL(), []string{maxSizeSingleMessage, maxSizeSingleMessage})
 
 	// ASSERT


### PR DESCRIPTION
https://aws.amazon.com/about-aws/whats-new/2025/08/amazon-sqs-max-payload-size-1mib/

- [x] Waiting for this Localstack update: https://github.com/localstack/localstack/issues/12956

## Proposed Changes


Changes proposed in this pull request:

- Bump sqs max body size to new 1 MiB limit.

## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*