### PR TITLE
feat: add subresource integrity to import map

### DIFF
--- a/weft/assets.go
+++ b/weft/assets.go
@@ -169,24 +169,27 @@ func CreateSubResourcePreload(args ...string) (template.HTML, error) {
 }
 
 // CreateImportMap generates an import map script tag which maps JS module asset filenames to their
-// respectful hash-prefixed path name. eg:
+// respectful hash-prefixed path name. Also includes subresource integrity values for these files. eg:
 //
-//	<script type="importmap" nonce="abcdefghijklmnop">
-//	{
-//		"imports":{
-//			"geonet-map.mjs":"/assets/js/77da7c4e-geonet-map.mjs"
+//		<script type="importmap" nonce="abcdefghijklmnop">
+//		{
+//			"imports":{
+//				"geonet-map.mjs":"/assets/js/77da7c4e-geonet-map.mjs"
+//			},
+//	        "integrity":{
+//	            "/assets/js/77da7c4e-geonet-map.mjs":"sha384-VbVf44SP6Q7kBOpKwzEQ3qhLRurPJ04Nrzv1JlaXnmSBXClEC94+WLmc97N8GfM1"
+//	        }
 //		}
-//	}
-//	</script>
+//		</script>
 func CreateImportMap(nonce string) template.HTML {
 
-	importMapping := make(map[string]string, 0)
-	for k, v := range assetHashes {
+	importMapping := make(map[string]*asset, 0)
+	for k, _ := range assetHashes {
 		if !strings.HasSuffix(k, ".mjs") {
 			continue
 		}
 		filename := path.Base(k)
-		importMapping[filename] = v
+		importMapping[filename] = assets[k]
 	}
 	if len(importMapping) == 0 {
 		return template.HTML("")
@@ -198,7 +201,7 @@ func CreateImportMap(nonce string) template.HTML {
 
 // createImportMapTag returns the <script> tag of type "importmap" to faciliate browser with
 // module resolution. Formatted to make readable in resulting source file.
-func createImportMapTag(importMapping map[string]string, nonce string) string {
+func createImportMapTag(importMapping map[string]*asset, nonce string) string {
 
 	importMap := "<script type=\"importmap\""
 	if nonce != "" {
@@ -214,9 +217,17 @@ func createImportMapTag(importMapping map[string]string, nonce string) string {
 	sort.Strings(keys)
 
 	for _, k := range keys {
-		importMap += fmt.Sprintf("\n\t\t\"%s\":\"%s\",", k, importMapping[k])
+		importMap += fmt.Sprintf("\n\t\t\"%s\":\"%s\",", k, importMapping[k].hashedPath)
 	}
 	importMap = strings.TrimSuffix(importMap, ",")
+
+	// Add subresource integrity values
+	importMap += "\n\t},\n\t\"integrity\":{"
+	for _, k := range keys {
+		importMap += fmt.Sprintf("\n\t\t\"%s\":\"%s\",", importMapping[k].hashedPath, importMapping[k].sri)
+	}
+	importMap = strings.TrimSuffix(importMap, ",")
+
 	importMap += "\n\t}\n}\n</script>"
 
 	return importMap

--- a/weft/assets_test.go
+++ b/weft/assets_test.go
@@ -185,19 +185,25 @@ func TestCreateImportTag(t *testing.T) {
 	work := []struct {
 		testName      string
 		nonce         string
-		importMapping map[string]string
+		importMapping map[string]*asset
 		expected      string
 	}{
 		{
 			"No nonce, one module file",
 			"",
-			map[string]string{
-				"test.mjs": "/assets/js/hashprefix-test.mjs",
+			map[string]*asset{
+				"test.mjs": &asset{
+					hashedPath: "/assets/js/hashprefix-test.mjs",
+					sri:        "sha384-abcd",
+				},
 			},
 			`<script type="importmap">
 {
 	"imports":{
 		"test.mjs":"/assets/js/hashprefix-test.mjs"
+	},
+	"integrity":{
+		"/assets/js/hashprefix-test.mjs":"sha384-abcd"
 	}
 }
 </script>`,
@@ -205,15 +211,25 @@ func TestCreateImportTag(t *testing.T) {
 		{
 			"Nonce present, two module files",
 			"abcdefg",
-			map[string]string{
-				"test1.mjs": "/assets/js/hashprefix-test1.mjs",
-				"test2.mjs": "/assets/js/hashprefix-test2.mjs",
+			map[string]*asset{
+				"test1.mjs": &asset{
+					hashedPath: "/assets/js/hashprefix-test1.mjs",
+					sri:        "sha384-efgh",
+				},
+				"test2.mjs": &asset{
+					hashedPath: "/assets/js/hashprefix-test2.mjs",
+					sri:        "sha384-ijkl",
+				},
 			},
 			`<script type="importmap" nonce="abcdefg">
 {
 	"imports":{
 		"test1.mjs":"/assets/js/hashprefix-test1.mjs",
 		"test2.mjs":"/assets/js/hashprefix-test2.mjs"
+	},
+	"integrity":{
+		"/assets/js/hashprefix-test1.mjs":"sha384-efgh",
+		"/assets/js/hashprefix-test2.mjs":"sha384-ijkl"
 	}
 }
 </script>`,


### PR DESCRIPTION
Reference: https://github.com/GeoNet/tickets/issues/19393

Changes proposed in this pull request:

- Add integrity value for js module files in import map.

Note: Tested by changing the SRI value to something wrong in the import map, the browser refuses to run it.

Adding this means we can remove all the `subResourcePreload` lines from `www-geonet` `border.html`, while still keeping subresource integrity for those scripts.

## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [ ] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*