### PR TITLE
feat: add error handler for internal use

### DIFF
--- a/weft/handlers.go
+++ b/weft/handlers.go
@@ -413,6 +413,33 @@ func TextError(e error, h http.Header, b *bytes.Buffer, nonce string) error {
 	return err
 }
 
+// TextInternalError exposes 500 errors to the client
+// for INTERNAL USERS!!!
+func TextInternalError(e error, h http.Header, b *bytes.Buffer, nonce string) error {
+	if b == nil {
+		return errors.New("nil *bytes.Buffer")
+	}
+
+	var msg string
+	switch Status(e) {
+	case http.StatusServiceUnavailable:
+		msg = "service unable error: " + e.Error()
+	case http.StatusInternalServerError:
+		msg = "internal server error: " + e.Error()
+	default:
+		// Fall back to the public-facing handler for all other statuses
+		return TextError(e, h, b, nonce)
+	}
+
+	// response
+	b.Reset()
+	h.Set("Surrogate-Control", "no-store")
+	h.Set("Content-Type", "text/plain; charset=utf-8")
+
+	_, err := b.WriteString(msg)
+	return err
+}
+
 // UseError sets Headers are set for intermediate caches.
 // The content of b is not changed.
 //


### PR DESCRIPTION
**User story:** As a internal user I want to see the error message on server side when a submision failed on client side (e.g. nema-mar-portal)

Changes proposed in this pull request:

- Add TextInternalError


## Production Changes

The following production changes are required to deploy these changes:

- None

## Review

Check the box that applies to this code review.  If necessary please seek help with adding a checklist guide for the reviewer.
When assigning the code review please consider the expertise needed to review the changes.

- [ ] This is a content (documentation, web page etc) only change.
- [x] This is a minor change (meta data, bug fix, improve test coverage etc).
- [ ] This is a larger change (new feature, significant refactoring etc).  Please use the code review guidelines to add a checklist below to guide the code reviewer.


### Code Review Guide

*Insert check list here if needed.*